### PR TITLE
Improve async handling in message and callback handlers

### DIFF
--- a/src/bot.js
+++ b/src/bot.js
@@ -33,7 +33,7 @@ try {
 
 // Listen for any kind of message.
 bot.on('message', async (msg) => {
-  handleMessage(bot, msg);
+  await handleMessage(bot, msg);
 });
 
 bot.on('callback_query', async (query) => {
@@ -41,31 +41,33 @@ bot.on('callback_query', async (query) => {
 });
 
 // Log polling errors
-bot.on('polling_error', (err) =>
-  sendLogMessage(bot, `Polling error: ${err.message}`)
+bot.on(
+  'polling_error',
+  async (err) => await sendLogMessage(bot, `Polling error: ${err.message}`)
 );
 
-bot.on('webhook_error', (err) =>
-  sendLogMessage(bot, `Webhook error: ${err.message}`)
+bot.on(
+  'webhook_error',
+  async (err) => await sendLogMessage(bot, `Webhook error: ${err.message}`)
 );
 
 // Log any errors that occur
-bot.on('error', (err) => {
-  sendLogMessage(bot, `Error occurred: ${err.message}`);
+bot.on('error', async (err) => {
+  await sendLogMessage(bot, `Error occurred: ${err.message}`);
 });
 
-process.on('uncaughtException', (err) => {
-  sendLogMessage(bot, `Uncaught exception: ${err.message}`);
+process.on('uncaughtException', async (err) => {
+  await sendLogMessage(bot, `Uncaught exception: ${err.message}`);
   console.error('Uncaught exception:', err);
 });
 
-process.on('unhandledRejection', (reason) => {
-  sendLogMessage(bot, `Unhandled rejection: ${reason}`);
+process.on('unhandledRejection', async (reason) => {
+  await sendLogMessage(bot, `Unhandled rejection: ${reason}`);
   console.error('Unhandled rejection:', reason);
 });
 
-process.on('exit', (code) => {
-  sendLogMessage(bot, `Process exited with code: ${code}`);
+process.on('exit', async (code) => {
+  await sendLogMessage(bot, `Process exited with code: ${code}`);
   console.log(`Process exited with code: ${code}`);
 });
 

--- a/src/callbackQueryHandler.js
+++ b/src/callbackQueryHandler.js
@@ -29,7 +29,7 @@ exports.handleCallbackQuery = async function (bot, query) {
     case CHIP_CALLBACK_TYPE:
       return handleChipCallback(bot, query);
     default:
-      sendLogMessage(bot, `Unknown callback type: ${callbackType}`);
+      await sendLogMessage(bot, `Unknown callback type: ${callbackType}`);
   }
 };
 
@@ -44,7 +44,7 @@ async function handlePhotoCallback(bot, query) {
   );
 
   // Optional: edit the message to confirm
-  bot.editMessageText(
+  await bot.editMessageText(
     `Photo labeled as ${type.toUpperCase()}. Wait for extracted JSON data...`,
     {
       chat_id: chatId,
@@ -53,7 +53,7 @@ async function handlePhotoCallback(bot, query) {
   );
 
   // Answer callback to remove "Loading..." spinner
-  bot.answerCallbackQuery(query.id);
+  await bot.answerCallbackQuery(query.id);
 
   const fileDetails = photoCache[fileId];
   try {
@@ -66,14 +66,14 @@ async function handlePhotoCallback(bot, query) {
     storeInCache(chatId, type, extractedData);
     delete bestTeamsCache[chatId];
 
-    bot
+    await bot
       .sendMessage(chatId, getPrintableCache(chatId, type), {
         parse_mode: 'Markdown',
       })
       .catch((err) => console.error('Error sending extracted data:', err));
   } catch (err) {
     console.error('Error extracting data from photo:', err);
-    bot
+    await bot
       .sendMessage(
         chatId,
         'An error occurred while extracting data from the photo.'
@@ -83,7 +83,7 @@ async function handlePhotoCallback(bot, query) {
       );
   }
 }
-function handleChipCallback(bot, query) {
+async function handleChipCallback(bot, query) {
   const chatId = query.message.chat.id;
   const messageId = query.message.message_id;
   const chip = query.data.split(':')[1];
@@ -93,13 +93,13 @@ function handleChipCallback(bot, query) {
   }
 
   // Optional: edit the message to confirm
-  bot.editMessageText(`Selected chip: ${chip.toUpperCase()}.`, {
+  await bot.editMessageText(`Selected chip: ${chip.toUpperCase()}.`, {
     chat_id: chatId,
     message_id: messageId,
   });
 
   // Answer callback to remove "Loading..." spinner
-  bot.answerCallbackQuery(query.id);
+  await bot.answerCallbackQuery(query.id);
 }
 
 function storeInCache(chatId, type, extractedData) {

--- a/src/callbackQueryHandler.js
+++ b/src/callbackQueryHandler.js
@@ -25,9 +25,9 @@ exports.handleCallbackQuery = async function (bot, query) {
 
   switch (callbackType) {
     case PHOTO_CALLBACK_TYPE:
-      return handlePhotoCallback(bot, query);
+      return await handlePhotoCallback(bot, query);
     case CHIP_CALLBACK_TYPE:
-      return handleChipCallback(bot, query);
+      return await handleChipCallback(bot, query);
     default:
       await sendLogMessage(bot, `Unknown callback type: ${callbackType}`);
   }

--- a/src/jsonDataExtraction.js
+++ b/src/jsonDataExtraction.js
@@ -41,7 +41,7 @@ exports.extractJsonDataFromPhotos = async function (bot, type, fileLinks) {
 
   const azureOpenAiTokensString = `Azure OpenAI model - ${AZURE_OPEN_AI_MODEL}, tokens - prompt: ${completion.usage.prompt_tokens}, completion: ${completion.usage.completion_tokens}, total: ${completion.usage.total_tokens}`;
   console.log(azureOpenAiTokensString);
-  sendLogMessage(bot, azureOpenAiTokensString);
+  await sendLogMessage(bot, azureOpenAiTokensString);
 
   return completion.choices[0].message.content;
 };

--- a/src/messageHandler.js
+++ b/src/messageHandler.js
@@ -6,39 +6,42 @@ const {
 const { handleTextMessage } = require('./textMessageHandler');
 const { handlePhotoMessage } = require('./photoMessageHandler');
 
-exports.handleMessage = function (bot, msg) {
+exports.handleMessage = async function (bot, msg) {
   const chatId = msg.chat.id;
   const chatName = getChatName(msg);
 
   if (!isAdminMessage(msg)) {
-    sendLogMessage(bot, `Message from unknown chat: ${chatName} (${chatId})`);
+    await sendLogMessage(
+      bot,
+      `Message from unknown chat: ${chatName} (${chatId})`
+    );
 
     return;
   }
 
-  sendLogMessage(bot, `Received a message from ${chatName} (${chatId})`);
+  await sendLogMessage(bot, `Received a message from ${chatName} (${chatId})`);
 
   // Handle text messages
   if (msg.text) {
-    handleTextMessage(bot, msg);
+    await handleTextMessage(bot, msg);
 
     return;
   }
 
   // Handle image messages (photos)
   if (msg.photo) {
-    handlePhotoMessage(bot, msg);
+    await handlePhotoMessage(bot, msg);
 
     return;
   }
 
-  sendLogMessage(
+  await sendLogMessage(
     bot,
     `Received unsupported message type from ${chatName} (${chatId}).`
   );
 
   // For unsupported message types
-  bot
+  await bot
     .sendMessage(chatId, 'Sorry, I only support text and image messages.')
     .catch((err) =>
       console.error('Error sending unsupported type reply:', err)

--- a/src/messageHandler.test.js
+++ b/src/messageHandler.test.js
@@ -38,7 +38,7 @@ describe('handleMessage', () => {
     jest.clearAllMocks();
   });
 
-  it('when got message from unknown sender, dont handle the message', () => {
+  it('when got message from unknown sender, dont handle the message', async () => {
     const msgMock = {
       chat: {
         id: 123456,
@@ -46,7 +46,7 @@ describe('handleMessage', () => {
       text: 'Hello',
     };
 
-    handleMessage(botMock, msgMock);
+    await handleMessage(botMock, msgMock);
     expect(botMock.sendMessage).not.toHaveBeenCalledWith(
       msgMock.chat.id,
       expect.any(String)
@@ -58,14 +58,14 @@ describe('handleMessage', () => {
     );
   });
 
-  it('when got unsupported message', () => {
+  it('when got unsupported message', async () => {
     const msgMock = {
       chat: {
         id: KILZI_CHAT_ID,
       },
       unsupportedField: 'Unsupported',
     };
-    handleMessage(botMock, msgMock);
+    await handleMessage(botMock, msgMock);
     expect(botMock.sendMessage).toHaveBeenCalledWith(
       msgMock.chat.id,
       'Sorry, I only support text and image messages.'

--- a/src/photoMessageHandler.js
+++ b/src/photoMessageHandler.js
@@ -6,7 +6,7 @@ const {
   PHOTO_CALLBACK_TYPE,
 } = require('./constants');
 
-exports.handlePhotoMessage = function (bot, msg) {
+exports.handlePhotoMessage = async function (bot, msg) {
   const chatId = msg.chat.id;
   const messageId = msg.message_id;
 
@@ -24,7 +24,7 @@ exports.handlePhotoMessage = function (bot, msg) {
   };
 
   // Reply with inline buttons
-  bot.sendMessage(chatId, 'What type is this photo?', {
+  await bot.sendMessage(chatId, 'What type is this photo?', {
     reply_to_message_id: messageId,
     reply_markup: {
       inline_keyboard: [

--- a/src/readJsonFromStorage.js
+++ b/src/readJsonFromStorage.js
@@ -33,12 +33,17 @@ exports.readJsonFromStorage = async function (bot) {
   const jsonString = await streamToString(downloadResponse.readableStreamBody);
   const jsonFromStorage = JSON.parse(jsonString);
 
-  sendLogMessage(
+  await sendLogMessage(
     bot,
     `jsonFromStorage downloaded successfully. Simulation: ${jsonFromStorage?.SimulationName}`
   );
 
-  const isValid = validateJsonData(bot, jsonFromStorage, LOG_CHANNEL_ID, false);
+  const isValid = await validateJsonData(
+    bot,
+    jsonFromStorage,
+    LOG_CHANNEL_ID,
+    false
+  );
 
   if (!isValid) {
     return;
@@ -87,8 +92,8 @@ exports.readJsonFromStorage = async function (bot) {
 Drivers not found in mapping: ${notFounds.drivers.join(', ')}
 🔴🔴🔴`;
 
-    sendLogMessage(bot, message);
-    sendMessageToAdmins(bot, message);
+    await sendLogMessage(bot, message);
+    await sendMessageToAdmins(bot, message);
   }
   if (notFounds.constructors.length > 0) {
     const message = `
@@ -96,8 +101,8 @@ Drivers not found in mapping: ${notFounds.drivers.join(', ')}
 Constructors not found in mapping: ${notFounds.constructors.join(', ')}
 🔴🔴🔴`;
 
-    sendLogMessage(bot, message);
-    sendMessageToAdmins(bot, message);
+    await sendLogMessage(bot, message);
+    await sendMessageToAdmins(bot, message);
   }
 };
 

--- a/src/textMessageHandler.js
+++ b/src/textMessageHandler.js
@@ -44,29 +44,29 @@ exports.handleTextMessage = async function (bot, msg) {
   switch (true) {
     // Check if message text is a number and delegate to the number handler
     case /^\d+$/.test(textTrimmed):
-      handleNumberMessage(bot, chatId, textTrimmed);
+      await handleNumberMessage(bot, chatId, textTrimmed);
 
       return;
     case msg.text === COMMAND_BEST_TEAMS:
-      handleBestTeamsMessage(bot, chatId);
+      await handleBestTeamsMessage(bot, chatId);
 
       return;
     case msg.text === COMMAND_CURRENT_TEAM_BUDGET:
-      return calcCurrentTeamBudget(bot, chatId);
+      return await calcCurrentTeamBudget(bot, chatId);
     case msg.text === COMMAND_CHIPS:
-      return handleChipsMessage(bot, msg);
+      return await handleChipsMessage(bot, msg);
     case msg.text === COMMAND_PRINT_CACHE:
-      return sendPrintableCache(chatId, bot);
+      return await sendPrintableCache(chatId, bot);
     case msg.text === COMMAND_RESET_CACHE:
-      return resetCacheForChat(chatId, bot);
+      return await resetCacheForChat(chatId, bot);
     case msg.text === COMMAND_LOAD_SIMULATION:
-      return handleLoadSimulation(bot, msg);
+      return await handleLoadSimulation(bot, msg);
     case msg.text === COMMAND_HELP:
-      return displayHelpMessage(bot, msg);
+      return await displayHelpMessage(bot, msg);
     case msg.text === COMMAND_GET_CURRENT_SIMULATION:
-      return handleGetCurrentSimulation(bot, msg);
+      return await handleGetCurrentSimulation(bot, msg);
     case msg.text === COMMAND_TRIGGER_SCRAPING:
-      return handleScrapingTrigger(bot, msg);
+      return await handleScrapingTrigger(bot, msg);
     default:
       handleJsonMessage(bot, msg, chatId);
       break;
@@ -184,7 +184,7 @@ async function handleJsonMessage(bot, msg, chatId) {
   try {
     jsonData = JSON.parse(msg.text);
   } catch (error) {
-    sendLogMessage(
+    await sendLogMessage(
       bot,
       `Failed to parse JSON data: ${msg.text}. Error: ${error.message}`
     );
@@ -208,7 +208,7 @@ async function handleJsonMessage(bot, msg, chatId) {
   currentTeamCache[chatId] = jsonData.CurrentTeam;
   delete bestTeamsCache[chatId];
 
-  sendPrintableCache(chatId, bot);
+  await sendPrintableCache(chatId, bot);
 }
 
 async function handleBestTeamsMessage(bot, chatId) {

--- a/src/textMessageHandler.test.js
+++ b/src/textMessageHandler.test.js
@@ -41,7 +41,7 @@ describe('handleTextMessage', () => {
     delete currentTeamCache[KILZI_CHAT_ID];
   });
 
-  it('when got message without json or number inside, return error', () => {
+  it('when got message without json or number inside, return error', async () => {
     const msgMock = {
       chat: {
         id: KILZI_CHAT_ID,
@@ -49,7 +49,7 @@ describe('handleTextMessage', () => {
       text: 'Hello',
     };
 
-    handleMessage(botMock, msgMock);
+    await handleMessage(botMock, msgMock);
     expect(botMock.sendMessage).toHaveBeenCalledWith(
       msgMock.chat.id,
       'Invalid JSON format. Please send valid JSON.'
@@ -65,13 +65,13 @@ describe('handleTextMessage', () => {
     );
   });
 
-  it('should handle /help command and send help message', () => {
+  it('should handle /help command and send help message', async () => {
     const msgMock = {
       chat: { id: KILZI_CHAT_ID },
       text: COMMAND_HELP,
     };
 
-    handleMessage(botMock, msgMock);
+    await handleMessage(botMock, msgMock);
     expect(botMock.sendMessage).toHaveBeenCalledWith(
       msgMock.chat.id,
       expect.stringContaining('*Available Commands:*'),
@@ -79,7 +79,7 @@ describe('handleTextMessage', () => {
     );
   });
 
-  it('should handle /reset_cache command and send reset confirmation', () => {
+  it('should handle /reset_cache command and send reset confirmation', async () => {
     const msgMock = {
       chat: { id: KILZI_CHAT_ID },
       text: COMMAND_RESET_CACHE,
@@ -92,7 +92,7 @@ describe('handleTextMessage', () => {
     bestTeamsCache[KILZI_CHAT_ID] = { some: 'data' };
     selectedChipCache[KILZI_CHAT_ID] = 'some_chip';
 
-    handleMessage(botMock, msgMock);
+    await handleMessage(botMock, msgMock);
 
     expect(botMock.sendMessage).toHaveBeenCalledWith(
       msgMock.chat.id,
@@ -105,7 +105,7 @@ describe('handleTextMessage', () => {
     expect(selectedChipCache[KILZI_CHAT_ID]).toBeUndefined();
   });
 
-  it('should handle /print_cache command and send cache messages', () => {
+  it('should handle /print_cache command and send cache messages', async () => {
     const msgMock = {
       chat: { id: KILZI_CHAT_ID },
       text: COMMAND_PRINT_CACHE,
@@ -116,43 +116,43 @@ describe('handleTextMessage', () => {
     constructorsCache[KILZI_CHAT_ID] = { some: 'data' };
     currentTeamCache[KILZI_CHAT_ID] = { some: 'data' };
 
-    handleMessage(botMock, msgMock);
+    await handleMessage(botMock, msgMock);
     expect(botMock.sendMessage).toHaveBeenCalledTimes(2);
   });
 
-  it('should handle /best_teams command and send missing cache message if no cache', () => {
+  it('should handle /best_teams command and send missing cache message if no cache', async () => {
     const msgMock = {
       chat: { id: KILZI_CHAT_ID },
       text: COMMAND_BEST_TEAMS,
     };
 
-    handleMessage(botMock, msgMock);
+    await handleMessage(botMock, msgMock);
     expect(botMock.sendMessage).toHaveBeenCalledWith(
       msgMock.chat.id,
       'Missing cached data. Please send images or JSON data for drivers, constructors, and current team first.'
     );
   });
 
-  it('should handle number message and send no cached teams message if no cache', () => {
+  it('should handle number message and send no cached teams message if no cache', async () => {
     const msgMock = {
       chat: { id: KILZI_CHAT_ID },
       text: '1',
     };
 
-    handleMessage(botMock, msgMock);
+    await handleMessage(botMock, msgMock);
     expect(botMock.sendMessage).toHaveBeenCalledWith(
       msgMock.chat.id,
       expect.stringContaining('No cached teams available')
     );
   });
 
-  it('should handle invalid JSON and send error', () => {
+  it('should handle invalid JSON and send error', async () => {
     const msgMock = {
       chat: { id: KILZI_CHAT_ID },
       text: '{invalidJson:}',
     };
 
-    handleMessage(botMock, msgMock);
+    await handleMessage(botMock, msgMock);
     expect(botMock.sendMessage).toHaveBeenCalledWith(
       msgMock.chat.id,
       'Invalid JSON format. Please send valid JSON.'
@@ -163,7 +163,7 @@ describe('handleTextMessage', () => {
     );
   });
 
-  it('should calculate and send current team budget correctly', () => {
+  it('should calculate and send current team budget correctly', async () => {
     const msgMock = {
       chat: { id: KILZI_CHAT_ID },
       text: COMMAND_CURRENT_TEAM_BUDGET,
@@ -195,7 +195,7 @@ describe('handleTextMessage', () => {
       overallBudget: expectedBudget,
     });
 
-    handleMessage(botMock, msgMock);
+    await handleMessage(botMock, msgMock);
 
     expect(botMock.sendMessage).toHaveBeenCalledWith(
       msgMock.chat.id,
@@ -223,7 +223,7 @@ describe('handleTextMessage', () => {
     );
   });
 
-  it('should send missing cache message if drivers cache is missing', () => {
+  it('should send missing cache message if drivers cache is missing', async () => {
     const msgMock = {
       chat: { id: KILZI_CHAT_ID },
       text: COMMAND_CURRENT_TEAM_BUDGET,
@@ -236,7 +236,7 @@ describe('handleTextMessage', () => {
       costCapRemaining: 0,
     };
 
-    handleMessage(botMock, msgMock);
+    await handleMessage(botMock, msgMock);
 
     expect(botMock.sendMessage).toHaveBeenCalledWith(
       msgMock.chat.id,
@@ -244,7 +244,7 @@ describe('handleTextMessage', () => {
     );
   });
 
-  it('should send missing cache message if constructors cache is missing', () => {
+  it('should send missing cache message if constructors cache is missing', async () => {
     const msgMock = {
       chat: { id: KILZI_CHAT_ID },
       text: COMMAND_CURRENT_TEAM_BUDGET,
@@ -256,7 +256,7 @@ describe('handleTextMessage', () => {
       costCapRemaining: 0,
     };
 
-    handleMessage(botMock, msgMock);
+    await handleMessage(botMock, msgMock);
 
     expect(botMock.sendMessage).toHaveBeenCalledWith(
       msgMock.chat.id,
@@ -264,7 +264,7 @@ describe('handleTextMessage', () => {
     );
   });
 
-  it('should send missing cache message if current team cache is missing', () => {
+  it('should send missing cache message if current team cache is missing', async () => {
     const msgMock = {
       chat: { id: KILZI_CHAT_ID },
       text: COMMAND_CURRENT_TEAM_BUDGET,
@@ -272,7 +272,7 @@ describe('handleTextMessage', () => {
     driversCache[KILZI_CHAT_ID] = { VER: { price: 30.5 } };
     constructorsCache[KILZI_CHAT_ID] = { RBR: { price: 20.0 } };
 
-    handleMessage(botMock, msgMock);
+    await handleMessage(botMock, msgMock);
 
     expect(botMock.sendMessage).toHaveBeenCalledWith(
       msgMock.chat.id,

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -13,14 +13,14 @@ const {
   EXTRACT_JSON_FROM_CURRENT_TEAM_PHOTO_SYSTEM_PROMPT,
 } = require('../prompts');
 
-exports.sendMessage = function (bot, chatId, message) {
+exports.sendMessage = async function (bot, chatId, message) {
   if (!chatId) {
     console.error('Chat ID is not set');
 
     return;
   }
 
-  bot.sendMessage(chatId, message);
+  await bot.sendMessage(chatId, message);
 };
 
 exports.sendLogMessage = function (bot, logMessage) {
@@ -73,7 +73,7 @@ exports.mapPhotoTypeToSystemPrompt = {
   [CURRENT_TEAM_PHOTO_TYPE]: EXTRACT_JSON_FROM_CURRENT_TEAM_PHOTO_SYSTEM_PROMPT,
 };
 
-exports.validateJsonData = function (
+exports.validateJsonData = async function (
   bot,
   jsonData,
   chatId = LOG_CHANNEL_ID,
@@ -84,7 +84,7 @@ exports.validateJsonData = function (
       bot,
       `Invalid JSON data. Expected 20 drivers under "Drivers" property'.`
     );
-    bot
+    await bot
       .sendMessage(
         chatId,
         'Invalid JSON data. Please ensure it contains 20 drivers under "Drivers" property.'
@@ -99,7 +99,7 @@ exports.validateJsonData = function (
       bot,
       `Invalid JSON data. Expected 10 constructors under "Constructors" property'.`
     );
-    bot
+    await bot
       .sendMessage(
         chatId,
         'Invalid JSON data. Please ensure it contains 10 constructors under "Constructors" property.'
@@ -126,7 +126,7 @@ exports.validateJsonData = function (
       bot,
       `Invalid JSON data. Expected 5 drivers, 2 constructors, drsBoost, freeTransfers, and costCapRemaining properties under "CurrentTeam" property'.`
     );
-    bot
+    await bot
       .sendMessage(
         chatId,
         'Invalid JSON data. Please ensure it contains the required properties under "CurrentTeam" property.'
@@ -156,10 +156,13 @@ exports.calculateTeamBudget = function (team, drivers, constructors) {
   };
 };
 
-exports.triggerScraping = async function (bot) {
+exports.triggerScraping = async function (bot, chatId) {
   const url = process.env.AZURE_LOGICAPP_TRIGGER_URL;
   if (!url) {
-    bot.sendMessage(chatId, 'Error: Scraping trigger URL is not configured.');
+    await bot.sendMessage(
+      chatId,
+      'Error: Scraping trigger URL is not configured.'
+    );
 
     return;
   }

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -23,7 +23,7 @@ exports.sendMessage = async function (bot, chatId, message) {
   await bot.sendMessage(chatId, message);
 };
 
-exports.sendLogMessage = function (bot, logMessage) {
+exports.sendLogMessage = async function (bot, logMessage) {
   if (!LOG_CHANNEL_ID) {
     console.error('LOG_CHANNEL_ID is not set');
 
@@ -38,16 +38,16 @@ env: ${process.env.NODE_ENV === 'production' ? 'prod' : 'dev'}`;
 pid: ${process.pid}`;
   }
 
-  exports.sendMessage(bot, LOG_CHANNEL_ID, log);
+  await exports.sendMessage(bot, LOG_CHANNEL_ID, log);
 };
 
-exports.sendMessageToAdmins = function (bot, message) {
+exports.sendMessageToAdmins = async function (bot, message) {
   const adminChatIds = [KILZI_CHAT_ID, DORSE_CHAT_ID];
   const msg = `BOT: ${message}`;
 
-  adminChatIds.forEach((chatId) => {
-    exports.sendMessage(bot, chatId, msg);
-  });
+  for (const chatId of adminChatIds) {
+    await exports.sendMessage(bot, chatId, msg);
+  }
 };
 
 exports.getChatName = function (msg) {
@@ -80,7 +80,7 @@ exports.validateJsonData = async function (
   validateCurrentTeam = true
 ) {
   if (!jsonData.Drivers || jsonData.Drivers.length !== 20) {
-    exports.sendLogMessage(
+    await exports.sendLogMessage(
       bot,
       `Invalid JSON data. Expected 20 drivers under "Drivers" property'.`
     );
@@ -95,7 +95,7 @@ exports.validateJsonData = async function (
   }
 
   if (!jsonData.Constructors || jsonData.Constructors.length !== 10) {
-    exports.sendLogMessage(
+    await exports.sendLogMessage(
       bot,
       `Invalid JSON data. Expected 10 constructors under "Constructors" property'.`
     );
@@ -122,7 +122,7 @@ exports.validateJsonData = async function (
       jsonData.CurrentTeam.costCapRemaining === null ||
       jsonData.CurrentTeam.costCapRemaining === undefined)
   ) {
-    exports.sendLogMessage(
+    await exports.sendLogMessage(
       bot,
       `Invalid JSON data. Expected 5 drivers, 2 constructors, drsBoost, freeTransfers, and costCapRemaining properties under "CurrentTeam" property'.`
     );

--- a/src/utils/utils.test.js
+++ b/src/utils/utils.test.js
@@ -51,7 +51,7 @@ describe('utils', () => {
   });
 
   describe('sendLogMessage', () => {
-    it('when LOG_CHANNEL_ID is undefined, bot.sendMessage does not have been called', () => {
+    it('when LOG_CHANNEL_ID is undefined, bot.sendMessage does not have been called', async () => {
       // Reset module registry to ensure the mocks take effect
       jest.resetModules();
       // Mock the constants module so that LOG_CHANNEL_ID is undefined
@@ -66,7 +66,7 @@ describe('utils', () => {
 
       // Re-require utils so it picks up the mocked constants
       const { sendLogMessage } = require('./utils');
-      sendLogMessage(botMock, 'Log message without channel ID');
+      await sendLogMessage(botMock, 'Log message without channel ID');
 
       expect(botMock.sendMessage).not.toHaveBeenCalled();
       expect(consoleErrorSpy).toHaveBeenCalledWith('LOG_CHANNEL_ID is not set');
@@ -74,12 +74,12 @@ describe('utils', () => {
       consoleErrorSpy.mockRestore();
     });
 
-    it('when LOG_CHANNEL_ID is defined, bot.sendMessage has been called', () => {
+    it('when LOG_CHANNEL_ID is defined, bot.sendMessage has been called', async () => {
       const botMock = {
         sendMessage: jest.fn(),
       };
 
-      sendLogMessage(botMock, 'Log message with channel ID');
+      await sendLogMessage(botMock, 'Log message with channel ID');
 
       expect(botMock.sendMessage).toHaveBeenCalledWith(
         expect.any(Number), // LOG_CHANNEL_ID
@@ -87,13 +87,13 @@ describe('utils', () => {
       );
     });
 
-    it('when NODE_ENV is production, log message contains prod', () => {
+    it('when NODE_ENV is production, log message contains prod', async () => {
       process.env.NODE_ENV = 'production';
       const botMock = {
         sendMessage: jest.fn(),
       };
 
-      sendLogMessage(botMock, 'Log message in production');
+      await sendLogMessage(botMock, 'Log message in production');
 
       expect(botMock.sendMessage).toHaveBeenCalledWith(
         expect.any(Number), // LOG_CHANNEL_ID
@@ -101,13 +101,13 @@ describe('utils', () => {
       );
     });
 
-    it('when NODE_ENV is not production, log message contains dev', () => {
+    it('when NODE_ENV is not production, log message contains dev', async () => {
       process.env.NODE_ENV = 'development';
       const botMock = {
         sendMessage: jest.fn(),
       };
 
-      sendLogMessage(botMock, 'Log message in development');
+      await sendLogMessage(botMock, 'Log message in development');
 
       expect(botMock.sendMessage).toHaveBeenCalledWith(
         expect.any(Number), // LOG_CHANNEL_ID
@@ -267,14 +267,14 @@ describe('utils', () => {
     });
 
     it('returns true for valid JSON data', async () => {
-      const result = validateJsonData(botMock, validJsonData, 123);
+      const result = await validateJsonData(botMock, validJsonData, 123);
       expect(result).toBe(true);
       expect(botMock.sendMessage).not.toHaveBeenCalled();
     });
 
     it('returns false and sends message if Drivers is missing', async () => {
       const data = { ...validJsonData, Drivers: undefined };
-      const result = validateJsonData(botMock, data, 123);
+      const result = await validateJsonData(botMock, data, 123);
       expect(result).toBe(false);
       expect(botMock.sendMessage).toHaveBeenCalledWith(
         123,
@@ -284,7 +284,7 @@ describe('utils', () => {
 
     it('returns false and sends message if Drivers length is not 20', async () => {
       const data = { ...validJsonData, Drivers: Array(19).fill({}) };
-      const result = validateJsonData(botMock, data, 123);
+      const result = await validateJsonData(botMock, data, 123);
       expect(result).toBe(false);
       expect(botMock.sendMessage).toHaveBeenCalledWith(
         123,
@@ -294,7 +294,7 @@ describe('utils', () => {
 
     it('returns false and sends message if Constructors is missing', async () => {
       const data = { ...validJsonData, Constructors: undefined };
-      const result = validateJsonData(botMock, data, 123);
+      const result = await validateJsonData(botMock, data, 123);
       expect(result).toBe(false);
       expect(botMock.sendMessage).toHaveBeenCalledWith(
         123,
@@ -304,7 +304,7 @@ describe('utils', () => {
 
     it('returns false and sends message if Constructors length is not 10', async () => {
       const data = { ...validJsonData, Constructors: Array(9).fill({}) };
-      const result = validateJsonData(botMock, data, 123);
+      const result = await validateJsonData(botMock, data, 123);
       expect(result).toBe(false);
       expect(botMock.sendMessage).toHaveBeenCalledWith(
         123,
@@ -314,7 +314,7 @@ describe('utils', () => {
 
     it('returns false and sends message if CurrentTeam is missing', async () => {
       const data = { ...validJsonData, CurrentTeam: undefined };
-      const result = validateJsonData(botMock, data, 123);
+      const result = await validateJsonData(botMock, data, 123);
       expect(result).toBe(false);
       expect(botMock.sendMessage).toHaveBeenCalledWith(
         123,
@@ -327,7 +327,7 @@ describe('utils', () => {
         ...validJsonData,
         CurrentTeam: { ...validJsonData.CurrentTeam, drivers: undefined },
       };
-      const result = validateJsonData(botMock, data, 123);
+      const result = await validateJsonData(botMock, data, 123);
       expect(result).toBe(false);
       expect(botMock.sendMessage).toHaveBeenCalledWith(
         123,
@@ -343,7 +343,7 @@ describe('utils', () => {
           drivers: Array(4).fill('DRIVER'),
         },
       };
-      const result = validateJsonData(botMock, data, 123);
+      const result = await validateJsonData(botMock, data, 123);
       expect(result).toBe(false);
       expect(botMock.sendMessage).toHaveBeenCalledWith(
         123,
@@ -356,7 +356,7 @@ describe('utils', () => {
         ...validJsonData,
         CurrentTeam: { ...validJsonData.CurrentTeam, constructors: undefined },
       };
-      const result = validateJsonData(botMock, data, 123);
+      const result = await validateJsonData(botMock, data, 123);
       expect(result).toBe(false);
       expect(botMock.sendMessage).toHaveBeenCalledWith(
         123,
@@ -372,7 +372,7 @@ describe('utils', () => {
           constructors: Array(1).fill('CONSTRUCTOR'),
         },
       };
-      const result = validateJsonData(botMock, data, 123);
+      const result = await validateJsonData(botMock, data, 123);
       expect(result).toBe(false);
       expect(botMock.sendMessage).toHaveBeenCalledWith(
         123,
@@ -382,7 +382,7 @@ describe('utils', () => {
 
     it('returns false and sends message if CurrentTeam.drsBoost is missing', async () => {
       delete validJsonData.CurrentTeam.drsBoost;
-      const result = validateJsonData(botMock, validJsonData, 123);
+      const result = await validateJsonData(botMock, validJsonData, 123);
       expect(result).toBe(false);
       expect(botMock.sendMessage).toHaveBeenCalledWith(
         123,
@@ -392,7 +392,7 @@ describe('utils', () => {
 
     it('returns false and sends message if CurrentTeam.freeTransfers is missing', async () => {
       delete validJsonData.CurrentTeam.freeTransfers;
-      const result = validateJsonData(botMock, validJsonData, 123);
+      const result = await validateJsonData(botMock, validJsonData, 123);
       expect(result).toBe(false);
       expect(botMock.sendMessage).toHaveBeenCalledWith(
         123,
@@ -402,7 +402,7 @@ describe('utils', () => {
 
     it('returns false and sends message if CurrentTeam.costCapRemaining is missing', async () => {
       delete validJsonData.CurrentTeam.costCapRemaining;
-      const result = validateJsonData(botMock, validJsonData, 123);
+      const result = await validateJsonData(botMock, validJsonData, 123);
       expect(result).toBe(false);
       expect(botMock.sendMessage).toHaveBeenCalledWith(
         123,


### PR DESCRIPTION
- Added missing `await` before async bot methods (sendLogMessage, editMessageText, answerCallbackQuery, sendMessage)
- Converted callback handlers (handleChipCallback) and main message handler to async
- Updated tests to await `handleMessage`
- Ensures promise resolution and error handling consistency