### PR TITLE
Move help command line to the top of the help message output

### DIFF
--- a/src/textMessageHandler.js
+++ b/src/textMessageHandler.js
@@ -435,6 +435,7 @@ async function displayHelpMessage(bot, msg) {
     .sendMessage(
       chatId,
       `*Available Commands:*\n` +
+        `${COMMAND_HELP.replace(/_/g, '\\_')} - Show this help message.\n` +
         `${COMMAND_BEST_TEAMS.replace(
           /_/g,
           '\\_'
@@ -458,8 +459,7 @@ async function displayHelpMessage(bot, msg) {
         `${COMMAND_GET_CURRENT_SIMULATION.replace(
           /_/g,
           '\\_'
-        )} - Show the current simulation data and name.\n` +
-        `${COMMAND_HELP.replace(/_/g, '\\_')} - Show this help message.\n\n` +
+        )} - Show the current simulation data and name.\n\n` +
         `${
           isAdmin
             ? '*Admin Commands:*\n' +


### PR DESCRIPTION
Reorder the help command in displayHelpMessage so it appears first and remove its duplicate entry, improving visibility of the `/help` command.