### PR TITLE
Refactor user teams cache to use object mapping and centralize logging

### DIFF
--- a/src/azureStorageService.js
+++ b/src/azureStorageService.js
@@ -160,7 +160,7 @@ async function listAllUserTeamData() {
       initializeAzureStorage();
     }
 
-    const userTeams = [];
+    const userTeams = {};
     const prefix = 'user-teams/';
 
     // List all blobs in the user-teams directory
@@ -171,7 +171,7 @@ async function listAllUserTeamData() {
       // Get the team data for this user
       const teamData = await getUserTeam(chatId);
       if (teamData) {
-        userTeams.push({ chatId, teamData });
+        userTeams[chatId] = teamData;
       }
     }
 

--- a/src/azureStorageService.test.js
+++ b/src/azureStorageService.test.js
@@ -193,10 +193,10 @@ describe('azureStorageService', () => {
 
       const result = await azureStorageService.listAllUserTeamData();
 
-      expect(result).toEqual([
-        { chatId: '123', teamData: mockTeam1 },
-        { chatId: '456', teamData: mockTeam2 },
-      ]);
+      expect(result).toEqual({
+        123: mockTeam1,
+        456: mockTeam2,
+      });
     });
   });
 });

--- a/src/cacheInitializer.js
+++ b/src/cacheInitializer.js
@@ -5,7 +5,11 @@ const {
   simulationNameCache,
   sharedKey,
 } = require('./cache');
-const { validateJsonData } = require('./utils');
+const {
+  sendLogMessage,
+  sendMessageToAdmins,
+  validateJsonData,
+} = require('./utils');
 const {
   LOG_CHANNEL_ID,
   NAME_TO_CODE_DRIVERS_MAPPING,
@@ -22,8 +26,8 @@ async function initializeCaches(bot) {
   // Get main fantasy data
   const jsonFromStorage = await azureStorageService.getFantasyData();
 
-  await bot.sendMessage(
-    LOG_CHANNEL_ID,
+  await sendLogMessage(
+    bot,
     `jsonFromStorage downloaded successfully. Simulation: ${jsonFromStorage?.SimulationName}`
   );
 
@@ -85,7 +89,8 @@ async function initializeCaches(bot) {
 Drivers not found in mapping: ${notFounds.drivers.join(', ')}
 🔴🔴🔴`;
 
-    await bot.sendMessage(LOG_CHANNEL_ID, message);
+    await sendLogMessage(bot, message);
+    await sendMessageToAdmins(bot, message);
   }
 
   if (notFounds.constructors.length > 0) {
@@ -94,18 +99,17 @@ Drivers not found in mapping: ${notFounds.drivers.join(', ')}
 Constructors not found in mapping: ${notFounds.constructors.join(', ')}
 🔴🔴🔴`;
 
-    await bot.sendMessage(LOG_CHANNEL_ID, message);
+    await sendLogMessage(bot, message);
+    await sendMessageToAdmins(bot, message);
   }
 
   // Load all user teams into cache
   const userTeams = await azureStorageService.listAllUserTeamData();
-  for (const { chatId, teamData } of userTeams) {
-    currentTeamCache[chatId] = teamData;
-  }
+  Object.assign(currentTeamCache, userTeams);
 
-  await bot.sendMessage(
-    LOG_CHANNEL_ID,
-    `Loaded ${userTeams.length} user teams from storage`
+  await sendLogMessage(
+    bot,
+    `Loaded ${Object.keys(userTeams).length} user teams from storage`
   );
 }
 


### PR DESCRIPTION
- Change listAllUserTeamData to return an object keyed by chatId instead of an array
- Update tests to expect object format for user teams
- Replace direct bot.sendMessage calls with sendLogMessage and sendMessageToAdmins
- Streamline cache initialization by merging userTeams via Object.assign
- Adjust tests to mock and verify new logging utilities