### PR TITLE
Add weather forecast caching and unified API call in nextRace handler

### DIFF
--- a/src/cache.js
+++ b/src/cache.js
@@ -27,6 +27,8 @@ exports.selectedChipCache = {};
 
 // In-memory cache for next race info
 exports.nextRaceInfoCache = {};
+// In-memory cache for weather forecast
+exports.weatherForecastCache = {};
 
 exports.getPrintableCache = function (chatId, type) {
   const driversData = exports.driversCache[chatId];

--- a/src/utils/weatherApi.js
+++ b/src/utils/weatherApi.js
@@ -3,21 +3,22 @@
 const fetch = require('node-fetch');
 
 /**
- * Fetches weather forecast for a given lat/lon and date.
- * Returns an object with temperature, precipitation probability, and wind speed for the specified date.
+ * Fetches weather forecast for two given lat/lon and dates.
+ * Returns an object with forecasts for both dates.
  * @param {number} lat
  * @param {number} lon
- * @param {Date} date - JS Date object (UTC)
- * @returns {Promise<{temperature: number, precipitation: number, wind: number}>}
+ * @param {Date} date1 - First JS Date object (UTC)
+ * @param {Date} date2 - Second JS Date object (UTC)
+ * @returns {Promise<{date1Forecast: {temperature: number, precipitation: number, wind: number}, date2Forecast: {temperature: number, precipitation: number, wind: number}}>}
  */
-async function getWeatherForecast(lat, lon, date) {
-  // Format date as YYYY-MM-DD
-  const yyyy = date.getUTCFullYear();
-  const mm = String(date.getUTCMonth() + 1).padStart(2, '0');
-  const dd = String(date.getUTCDate()).padStart(2, '0');
-  const dateStr = `${yyyy}-${mm}-${dd}`;
+async function getWeatherForecast(lat, lon, date1, date2) {
+  // Determine start and end dates for the API call
+  const apiStartDate = date1 < date2 ? date1 : date2;
+  const apiEndDate = date1 > date2 ? date1 : date2;
+  const startDateStr = formatToYYYYMMDD(apiStartDate);
+  const endDateStr = formatToYYYYMMDD(apiEndDate);
 
-  const url = `https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lon}&hourly=temperature_2m,precipitation_probability,wind_speed_10m&start_date=${dateStr}&end_date=${dateStr}&timezone=UTC`;
+  const url = `https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lon}&hourly=temperature_2m,precipitation_probability,wind_speed_10m&start_date=${startDateStr}&end_date=${endDateStr}&timezone=UTC`;
 
   // Set up a 30-second timeout using AbortController
   const controller = new AbortController();
@@ -40,16 +41,44 @@ async function getWeatherForecast(lat, lon, date) {
   }
   const data = await res.json();
 
-  // Find the forecast for the exact hour/minute of the provided date (UTC)
-  const hh = String(date.getUTCHours()).padStart(2, '0');
-  const min = String(date.getUTCMinutes()).padStart(2, '0');
-  const targetIso = `${dateStr}T${hh}:${min}`;
-  const hourIndex = data.hourly.time.findIndex((t) => t.startsWith(targetIso));
+  const forecast1 = extractHourlyForecast(data, date1);
+  const forecast2 = extractHourlyForecast(data, date2);
 
   return {
-    temperature: data.hourly.temperature_2m[hourIndex],
-    precipitation: data.hourly.precipitation_probability[hourIndex],
-    wind: data.hourly.wind_speed_10m[hourIndex],
+    date1Forecast: forecast1,
+    date2Forecast: forecast2,
+  };
+}
+
+// Helper to format date as YYYY-MM-DD
+function formatToYYYYMMDD(d) {
+  const yyyy = d.getUTCFullYear();
+  const mm = String(d.getUTCMonth() + 1).padStart(2, '0');
+  const dd = String(d.getUTCDate()).padStart(2, '0');
+
+  return `${yyyy}-${mm}-${dd}`;
+}
+
+// Helper to extract forecast for a specific date/time
+function extractHourlyForecast(apiData, targetDate) {
+  const yyyy = targetDate.getUTCFullYear();
+  const mm = String(targetDate.getUTCMonth() + 1).padStart(2, '0');
+  const dd = String(targetDate.getUTCDate()).padStart(2, '0');
+  const dateStr = `${yyyy}-${mm}-${dd}`;
+  const hh = String(targetDate.getUTCHours()).padStart(2, '0');
+  // Open-Meteo hourly data is typically at the start of the hour
+  const targetIso = `${dateStr}T${hh}:00`;
+  const hourIndex = apiData.hourly.time.findIndex((t) => t === targetIso);
+
+  if (hourIndex === -1) {
+    // Not found, return nulls
+    return { temperature: null, precipitation: null, wind: null };
+  }
+
+  return {
+    temperature: apiData.hourly.temperature_2m[hourIndex],
+    precipitation: apiData.hourly.precipitation_probability[hourIndex],
+    wind: apiData.hourly.wind_speed_10m[hourIndex],
   };
 }
 

--- a/src/utils/weatherApi.test.js
+++ b/src/utils/weatherApi.test.js
@@ -10,7 +10,7 @@ describe('getWeatherForecast', () => {
     jest.clearAllMocks();
   });
 
-  it('returns correct weather data for a given date and location', async () => {
+  it('returns correct weather data for two given dates and location', async () => {
     const mockData = {
       hourly: {
         time: ['2025-05-25T13:00', '2025-05-25T14:00'],
@@ -26,26 +26,34 @@ describe('getWeatherForecast', () => {
 
     const lat = 43.7347;
     const lon = 7.42056;
-    const date = new Date(Date.UTC(2025, 4, 25, 13, 0)); // 2025-05-25T13:00:00Z
+    const date1 = new Date(Date.UTC(2025, 4, 25, 13, 0)); // 2025-05-25T13:00:00Z
+    const date2 = new Date(Date.UTC(2025, 4, 25, 14, 0)); // 2025-05-25T14:00:00Z
 
-    const result = await getWeatherForecast(lat, lon, date);
+    const result = await getWeatherForecast(lat, lon, date1, date2);
 
     expect(result).toEqual({
-      temperature: 22.5,
-      precipitation: 10,
-      wind: 5.2,
+      date1Forecast: {
+        temperature: 22.5,
+        precipitation: 10,
+        wind: 5.2,
+      },
+      date2Forecast: {
+        temperature: 23.1,
+        precipitation: 20,
+        wind: 6.1,
+      },
     });
     expect(fetch).toHaveBeenCalled();
   });
 
   it('throws if fetch fails', async () => {
     fetch.mockResolvedValue({ ok: false });
-    await expect(getWeatherForecast(1, 2, new Date())).rejects.toThrow(
-      'Failed to fetch weather data'
-    );
+    await expect(
+      getWeatherForecast(1, 2, new Date(), new Date())
+    ).rejects.toThrow('Failed to fetch weather data');
   });
 
-  it('returns undefined values if hour not found', async () => {
+  it('returns null values if hour not found', async () => {
     const mockData = {
       hourly: {
         time: ['2025-05-25T10:00'],
@@ -59,13 +67,21 @@ describe('getWeatherForecast', () => {
       json: async () => mockData,
     });
 
-    const date = new Date(Date.UTC(2025, 4, 25, 13, 0)); // 2025-05-25T13:00:00Z
-    const result = await getWeatherForecast(1, 2, date);
+    const date1 = new Date(Date.UTC(2025, 4, 25, 13, 0)); // 2025-05-25T13:00:00Z
+    const date2 = new Date(Date.UTC(2025, 4, 25, 14, 0)); // 2025-05-25T14:00:00Z
+    const result = await getWeatherForecast(1, 2, date1, date2);
 
     expect(result).toEqual({
-      temperature: undefined,
-      precipitation: undefined,
-      wind: undefined,
+      date1Forecast: {
+        temperature: null,
+        precipitation: null,
+        wind: null,
+      },
+      date2Forecast: {
+        temperature: null,
+        precipitation: null,
+        wind: null,
+      },
     });
   });
 });


### PR DESCRIPTION
- Introduce `weatherForecastCache` in cache.js
- Require and use cache in `textMessageHandler.js`
- Replace two separate getWeatherForecast calls with one unified call
- Cache qualifying and race forecasts under `sharedKey` with logging
- Update tests to clear and assert weatherForecastCache usage and log messages