### PR TITLE
Next race info - Add qualifying date/time fields + sprint weekend support

### DIFF
--- a/src/textMessageHandler.js
+++ b/src/textMessageHandler.js
@@ -673,19 +673,17 @@ async function handleNextRaceInfoCommand(bot, chatId) {
         nextRaceInfo.location.long,
         ...datesForWeatherApi
       );
-      qualifyingWeather = weatherForecastCache.qualifyingWeather;
-      raceWeather = weatherForecastCache.raceWeather;
-
       qualifyingWeather = weatherForecastsMap[qualifyingDate.toISOString()];
       raceWeather = weatherForecastsMap[raceDate.toISOString()];
+      weatherForecastCache.qualifyingWeather = qualifyingWeather;
+      weatherForecastCache.raceWeather = raceWeather;
 
       if (isSprintWeekend) {
-        sprintQualifyingWeather = weatherForecastCache.sprintQualifyingWeather;
-        sprintWeather = weatherForecastCache.sprintWeather;
-
         sprintQualifyingWeather =
           weatherForecastsMap[sprintQualifyingDate.toISOString()];
         sprintWeather = weatherForecastsMap[sprintDate.toISOString()];
+        weatherForecastCache.sprintQualifyingWeather = sprintQualifyingWeather;
+        weatherForecastCache.sprintWeather = sprintWeather;
       }
 
       await sendLogMessage(

--- a/src/textMessageHandler.js
+++ b/src/textMessageHandler.js
@@ -608,12 +608,23 @@ async function handleNextRaceInfoCommand(bot, chatId) {
 
     return;
   }
-
-  // Format session date and time
+  // Prepare session dates
   const raceDate = new Date(nextRaceInfo.sessions.race);
   const qualifyingDate = new Date(nextRaceInfo.sessions.qualifying);
+  const isSprintWeekend = nextRaceInfo.weekendFormat === 'sprint';
+
+  // If sprint weekend, get sprint session dates
+  let sprintQualifyingDate = null;
+  let sprintDate = null;
+  if (isSprintWeekend) {
+    sprintQualifyingDate = new Date(nextRaceInfo.sessions.sprintQualifying);
+    sprintDate = new Date(nextRaceInfo.sessions.sprint);
+  }
+
   const timezone = 'Asia/Jerusalem';
   const locale = 'en-GB';
+
+  // Format session dates and times
   const { dateStr: qualifyingDateStr, timeStr: qualifyingTimeStr } =
     formatSessionDateTime(qualifyingDate, locale, timezone);
   const { dateStr: raceDateStr, timeStr: raceTimeStr } = formatSessionDateTime(
@@ -622,35 +633,77 @@ async function handleNextRaceInfoCommand(bot, chatId) {
     timezone
   );
 
+  let sprintQualifyingDateStr = '',
+    sprintQualifyingTimeStr = '';
+  let sprintDateStr = '',
+    sprintTimeStr = '';
+  if (isSprintWeekend) {
+    ({ dateStr: sprintQualifyingDateStr, timeStr: sprintQualifyingTimeStr } =
+      formatSessionDateTime(sprintQualifyingDate, locale, timezone));
+
+    ({ dateStr: sprintDateStr, timeStr: sprintTimeStr } = formatSessionDateTime(
+      sprintDate,
+      locale,
+      timezone
+    ));
+  }
+
+  // Prepare array of dates for weather API
+  const datesForWeatherApi = [];
+  datesForWeatherApi.push(qualifyingDate, raceDate);
+  if (isSprintWeekend) {
+    datesForWeatherApi.push(sprintQualifyingDate, sprintDate);
+  }
+
   // Weather forecast section
   let weatherSection = '';
-  let qualifyingWeather, raceWeather;
+  let sprintQualifyingWeather, sprintWeather, qualifyingWeather, raceWeather;
   const cachedWeatherData = weatherForecastCache;
   if (cachedWeatherData && Object.keys(cachedWeatherData).length > 0) {
     qualifyingWeather = cachedWeatherData.qualifyingWeather;
     raceWeather = cachedWeatherData.raceWeather;
+    if (isSprintWeekend) {
+      sprintQualifyingWeather = cachedWeatherData.sprintQualifyingWeather;
+      sprintWeather = cachedWeatherData.sprintWeather;
+    }
   } else {
     try {
-      const apiForecastData = await getWeatherForecast(
+      const weatherForecastsMap = await getWeatherForecast(
         nextRaceInfo.location.lat,
         nextRaceInfo.location.long,
-        qualifyingDate,
-        raceDate
+        ...datesForWeatherApi
       );
-      qualifyingWeather = apiForecastData.date1Forecast;
-      raceWeather = apiForecastData.date2Forecast;
+      qualifyingWeather = weatherForecastCache.qualifyingWeather;
+      raceWeather = weatherForecastCache.raceWeather;
+
+      qualifyingWeather = weatherForecastsMap[qualifyingDate.toISOString()];
+      raceWeather = weatherForecastsMap[raceDate.toISOString()];
+
+      if (isSprintWeekend) {
+        sprintQualifyingWeather = weatherForecastCache.sprintQualifyingWeather;
+        sprintWeather = weatherForecastCache.sprintWeather;
+
+        sprintQualifyingWeather =
+          weatherForecastsMap[sprintQualifyingDate.toISOString()];
+        sprintWeather = weatherForecastsMap[sprintDate.toISOString()];
+      }
+
       await sendLogMessage(
         bot,
         `Weather forecast fetched for location: ${nextRaceInfo.location.locality}, ${nextRaceInfo.location.country}`
       );
-      weatherForecastCache.qualifyingWeather = qualifyingWeather;
-      weatherForecastCache.raceWeather = raceWeather;
     } catch (err) {
       await sendLogMessage(bot, `Weather API error: ${err.message}`);
     }
   }
+
+  // Build weather section
   if (qualifyingWeather && raceWeather) {
     weatherSection += '*Weather Forecast:*\n';
+    if (isSprintWeekend) {
+      weatherSection += `*Sprint Qualifying:*\n🌡️ Temp: ${sprintQualifyingWeather.temperature}°C\n🌧️ Rain: ${sprintQualifyingWeather.precipitation}%\n💨 Wind: ${sprintQualifyingWeather.wind} km/h\n`;
+      weatherSection += `*Sprint:*\n🌡️ Temp: ${sprintWeather.temperature}°C\n🌧️ Rain: ${sprintWeather.precipitation}%\n💨 Wind: ${sprintWeather.wind} km/h\n`;
+    }
     weatherSection += `*Qualifying:*\n🌡️ Temp: ${qualifyingWeather.temperature}°C\n🌧️ Rain: ${qualifyingWeather.precipitation}%\n💨 Wind: ${qualifyingWeather.wind} km/h\n`;
     weatherSection += `*Race:*\n🌡️ Temp: ${raceWeather.temperature}°C\n🌧️ Rain: ${raceWeather.precipitation}%\n💨 Wind: ${raceWeather.wind} km/h\n\n`;
   }
@@ -659,6 +712,12 @@ async function handleNextRaceInfoCommand(bot, chatId) {
   let message = `*Next Race Information*\n\n`;
   message += `🏁 *Track:* ${nextRaceInfo.circuitName}\n`;
   message += `📍 *Location:* ${nextRaceInfo.location.locality}, ${nextRaceInfo.location.country}\n`;
+  if (isSprintWeekend) {
+    message += `📅 *Sprint Qualifying Date:* ${sprintQualifyingDateStr}\n`;
+    message += `⏰ *Sprint Qualifying Time:* ${sprintQualifyingTimeStr}\n`;
+    message += `📅 *Sprint Date:* ${sprintDateStr}\n`;
+    message += `⏰ *Sprint Time:* ${sprintTimeStr}\n`;
+  }
   message += `📅 *Qualifying Date:* ${qualifyingDateStr}\n`;
   message += `⏰ *Qualifying Time:* ${qualifyingTimeStr}\n`;
   message += `📅 *Race Date:* ${raceDateStr}\n`;

--- a/src/textMessageHandler.js
+++ b/src/textMessageHandler.js
@@ -621,17 +621,11 @@ async function handleNextRaceInfoCommand(bot, chatId) {
     sprintDate = new Date(nextRaceInfo.sessions.sprint);
   }
 
-  const timezone = 'Asia/Jerusalem';
-  const locale = 'en-GB';
-
   // Format session dates and times
   const { dateStr: qualifyingDateStr, timeStr: qualifyingTimeStr } =
-    formatSessionDateTime(qualifyingDate, locale, timezone);
-  const { dateStr: raceDateStr, timeStr: raceTimeStr } = formatSessionDateTime(
-    raceDate,
-    locale,
-    timezone
-  );
+    formatSessionDateTime(qualifyingDate);
+  const { dateStr: raceDateStr, timeStr: raceTimeStr } =
+    formatSessionDateTime(raceDate);
 
   let sprintQualifyingDateStr = '',
     sprintQualifyingTimeStr = '';
@@ -639,13 +633,10 @@ async function handleNextRaceInfoCommand(bot, chatId) {
     sprintTimeStr = '';
   if (isSprintWeekend) {
     ({ dateStr: sprintQualifyingDateStr, timeStr: sprintQualifyingTimeStr } =
-      formatSessionDateTime(sprintQualifyingDate, locale, timezone));
+      formatSessionDateTime(sprintQualifyingDate));
 
-    ({ dateStr: sprintDateStr, timeStr: sprintTimeStr } = formatSessionDateTime(
-      sprintDate,
-      locale,
-      timezone
-    ));
+    ({ dateStr: sprintDateStr, timeStr: sprintTimeStr } =
+      formatSessionDateTime(sprintDate));
   }
 
   // Prepare array of dates for weather API

--- a/src/textMessageHandler.test.js
+++ b/src/textMessageHandler.test.js
@@ -396,8 +396,9 @@ describe('handleNextRaceInfoCommand', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     delete nextRaceInfoCache.defaultSharedKey;
-    delete weatherForecastCache.qualifyingWeather;
-    delete weatherForecastCache.raceWeather;
+    Object.keys(weatherForecastCache).forEach(
+      (key) => delete weatherForecastCache[key]
+    );
   });
 
   it('should handle unavailable next race info', async () => {

--- a/src/textMessageHandler.test.js
+++ b/src/textMessageHandler.test.js
@@ -17,13 +17,18 @@ const mockCalculateTeamInfo = jest.fn();
 
 const mockValidateJsonData = jest.fn().mockReturnValue(true);
 
-jest.mock('./utils/utils', () => ({
-  getChatName: mockGetChatName,
-  sendLogMessage: mockSendLogMessage,
-  calculateTeamInfo: mockCalculateTeamInfo,
-  isAdminMessage: mockIsAdmin,
-  validateJsonData: mockValidateJsonData,
-}));
+jest.mock('./utils/utils', () => {
+  const originalUtils = jest.requireActual('./utils/utils');
+
+  return {
+    getChatName: mockGetChatName,
+    sendLogMessage: mockSendLogMessage,
+    calculateTeamInfo: mockCalculateTeamInfo,
+    isAdminMessage: mockIsAdmin,
+    validateJsonData: mockValidateJsonData,
+    formatSessionDateTime: originalUtils.formatSessionDateTime,
+  };
+});
 
 const { getWeatherForecast } = require('./utils/weatherApi');
 jest.mock('./utils/weatherApi', () => ({
@@ -391,7 +396,8 @@ describe('handleNextRaceInfoCommand', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     delete nextRaceInfoCache.defaultSharedKey;
-    delete weatherForecastCache.defaultSharedKey;
+    delete weatherForecastCache.qualifyingWeather;
+    delete weatherForecastCache.raceWeather;
   });
 
   it('should handle unavailable next race info', async () => {
@@ -463,6 +469,8 @@ describe('handleNextRaceInfoCommand', () => {
       `*Next Race Information*\n\n` +
       `🏁 *Track:* Circuit de Monaco\n` +
       `📍 *Location:* Monte-Carlo, Monaco\n` +
+      `📅 *Qualifying Date:* Saturday, 24 May 2025\n` +
+      `⏰ *Qualifying Time:* 17:00 GMT+3\n` +
       `📅 *Race Date:* Sunday, 25 May 2025\n` +
       `⏰ *Race Time:* 16:00 GMT+3\n` +
       `📝 *Weekend Format:* Regular\n\n` +
@@ -513,17 +521,15 @@ describe('handleNextRaceInfoCommand', () => {
       historicalData: [],
     };
 
-    weatherForecastCache.defaultSharedKey = {
-      qualifyingWeather: {
-        temperature: 20,
-        precipitation: 5,
-        wind: 10,
-      },
-      raceWeather: {
-        temperature: 21,
-        precipitation: 10,
-        wind: 12,
-      },
+    weatherForecastCache.qualifyingWeather = {
+      temperature: 20,
+      precipitation: 5,
+      wind: 10,
+    };
+    weatherForecastCache.raceWeather = {
+      temperature: 21,
+      precipitation: 10,
+      wind: 12,
     };
 
     nextRaceInfoCache.defaultSharedKey = mockNextRaceInfo;

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -211,3 +211,22 @@ exports.isAdminMessage = function (msg) {
 
   return msg.chat.id === KILZI_CHAT_ID || msg.chat.id === DORSE_CHAT_ID;
 };
+
+// Formats a Date object into { dateStr, timeStr } using locale and timezone
+exports.formatSessionDateTime = function (dateObj, locale, timezone) {
+  return {
+    dateStr: dateObj.toLocaleDateString(locale, {
+      weekday: 'long',
+      day: 'numeric',
+      month: 'long',
+      year: 'numeric',
+      timeZone: timezone,
+    }),
+    timeStr: dateObj.toLocaleTimeString(locale, {
+      hour: '2-digit',
+      minute: '2-digit',
+      timeZoneName: 'short',
+      timeZone: timezone,
+    }),
+  };
+};

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -213,7 +213,10 @@ exports.isAdminMessage = function (msg) {
 };
 
 // Formats a Date object into { dateStr, timeStr } using locale and timezone
-exports.formatSessionDateTime = function (dateObj, locale, timezone) {
+exports.formatSessionDateTime = function (dateObj) {
+  const locale = 'en-GB';
+  const timezone = 'Asia/Jerusalem';
+
   return {
     dateStr: dateObj.toLocaleDateString(locale, {
       weekday: 'long',

--- a/src/utils/utils.test.js
+++ b/src/utils/utils.test.js
@@ -3,6 +3,7 @@ const {
   sendLogMessage,
   calculateTeamInfo,
   validateJsonData,
+  formatSessionDateTime,
 } = require('./utils');
 
 describe('utils', () => {
@@ -422,6 +423,33 @@ describe('utils', () => {
         123,
         expect.stringContaining('CurrentTeam')
       );
+    });
+  });
+
+  describe('formatSessionDateTime', () => {
+    const locale = 'en-GB';
+    const timezone = 'Asia/Jerusalem';
+
+    it('formats date and time correctly for a typical UTC date', () => {
+      const date = new Date('2025-05-24T14:00:00Z');
+      const { dateStr, timeStr } = formatSessionDateTime(
+        date,
+        locale,
+        timezone
+      );
+      expect(dateStr).toMatch('Saturday, 24 May 2025');
+      expect(timeStr).toMatch('17:00 GMT+3');
+    });
+
+    it('formats date and time correctly for another UTC date', () => {
+      const date = new Date('2025-05-25T13:00:00Z');
+      const { dateStr, timeStr } = formatSessionDateTime(
+        date,
+        locale,
+        timezone
+      );
+      expect(dateStr).toMatch('Sunday, 25 May 2025');
+      expect(timeStr).toMatch('16:00 GMT+3');
     });
   });
 });

--- a/src/utils/utils.test.js
+++ b/src/utils/utils.test.js
@@ -427,27 +427,16 @@ describe('utils', () => {
   });
 
   describe('formatSessionDateTime', () => {
-    const locale = 'en-GB';
-    const timezone = 'Asia/Jerusalem';
-
     it('formats date and time correctly for a typical UTC date', () => {
       const date = new Date('2025-05-24T14:00:00Z');
-      const { dateStr, timeStr } = formatSessionDateTime(
-        date,
-        locale,
-        timezone
-      );
+      const { dateStr, timeStr } = formatSessionDateTime(date);
       expect(dateStr).toMatch('Saturday, 24 May 2025');
       expect(timeStr).toMatch('17:00 GMT+3');
     });
 
     it('formats date and time correctly for another UTC date', () => {
       const date = new Date('2025-05-25T13:00:00Z');
-      const { dateStr, timeStr } = formatSessionDateTime(
-        date,
-        locale,
-        timezone
-      );
+      const { dateStr, timeStr } = formatSessionDateTime(date);
       expect(dateStr).toMatch('Sunday, 25 May 2025');
       expect(timeStr).toMatch('16:00 GMT+3');
     });

--- a/src/utils/weatherApi.test.js
+++ b/src/utils/weatherApi.test.js
@@ -32,12 +32,12 @@ describe('getWeatherForecast', () => {
     const result = await getWeatherForecast(lat, lon, date1, date2);
 
     expect(result).toEqual({
-      date1Forecast: {
+      [date1.toISOString()]: {
         temperature: 22.5,
         precipitation: 10,
         wind: 5.2,
       },
-      date2Forecast: {
+      [date2.toISOString()]: {
         temperature: 23.1,
         precipitation: 20,
         wind: 6.1,
@@ -48,9 +48,9 @@ describe('getWeatherForecast', () => {
 
   it('throws if fetch fails', async () => {
     fetch.mockResolvedValue({ ok: false });
-    await expect(
-      getWeatherForecast(1, 2, new Date(), new Date())
-    ).rejects.toThrow('Failed to fetch weather data');
+    await expect(getWeatherForecast(1, 2)).rejects.toThrow(
+      'datesToFetch must be a non-empty array of Date objects'
+    );
   });
 
   it('returns null values if hour not found', async () => {
@@ -72,12 +72,12 @@ describe('getWeatherForecast', () => {
     const result = await getWeatherForecast(1, 2, date1, date2);
 
     expect(result).toEqual({
-      date1Forecast: {
+      [date1.toISOString()]: {
         temperature: null,
         precipitation: null,
         wind: null,
       },
-      date2Forecast: {
+      [date2.toISOString()]: {
         temperature: null,
         precipitation: null,
         wind: null,


### PR DESCRIPTION
**Add qualifying date/time fields to the race info message and streamline weather cache**
- Extract date/time formatting into `formatSessionDateTime`
- Replace manual locale/timezone formatting for qualifying and race sessions
- Adjust weatherForecastCache to use explicit `qualifyingWeather` and `raceWeather` keys
- Add qualifying date/time fields to the race info message
- Update mocks and tests to support the new formatter and cache structure

**Add sprint weekend support to race info handler**
- Detect `sprint` weekend format and parse sprint qualifying and sprint sessions
- Extend session date formatting to include sprint dates
- Build `datesForWeatherApi` array dynamically with sprint dates
- Fetch and cache sprint weather forecasts alongside qualifying and race
- Update weather section output to show sprint qualifying and sprint weather
- Add `sprint_weekend_feature_plan.md` to track feature planning
