### PR TITLE
Update “(New)” tags to emoji for new items in messages

### DIFF
--- a/src/commandsHandler/numberInputHandler.js
+++ b/src/commandsHandler/numberInputHandler.js
@@ -228,7 +228,7 @@ function getDriverAndConstructorsDetailsMessage(cachedJsonData, changesToTeam) {
     )} (${driver.priceChange.toFixed(2)}M)`;
 
     if (driver.isNew) {
-      message += ' (New)';
+      message += ' 🆕';
     }
     message += '\n';
   });
@@ -240,7 +240,7 @@ function getDriverAndConstructorsDetailsMessage(cachedJsonData, changesToTeam) {
     )} (${constructor.priceChange.toFixed(2)}M)`;
 
     if (constructor.isNew) {
-      message += ' (New)';
+      message += ' 🆕';
     }
     message += '\n';
   });

--- a/src/commandsHandler/numberInputHandler.test.js
+++ b/src/commandsHandler/numberInputHandler.test.js
@@ -182,9 +182,9 @@ describe('handleNumberMessage', () => {
       `*Δ Points:* +10.50\n` +
       `*Δ Price:* -2.30M\n` +
       `\n*Drivers:*\n` +
-      `HAM (DRS): 60.00 (0.10M) (New)\n` +
+      `HAM (DRS): 60.00 (0.10M) 🆕\n` +
       `\n*Constructors:*\n` +
-      `MER: 32.00 (0.20M) (New)\n`;
+      `MER: 32.00 (0.20M) 🆕\n`;
 
     expect(botMock.sendMessage).toHaveBeenCalledWith(
       KILZI_CHAT_ID,
@@ -261,7 +261,7 @@ describe('handleNumberMessage', () => {
       `*Δ Points:* +5.00\n` +
       `*Δ Price:* 0.00M\n` +
       `\n*Drivers:*\n` +
-      `VER (DRS): 50.00 (0.20M) (New)\n` +
+      `VER (DRS): 50.00 (0.20M) 🆕\n` +
       `\n*Constructors:*\n` +
       `RBR: 35.00 (0.30M)\n`;
 


### PR DESCRIPTION
Replaced plain “(New)” markers with the 🆕 emoji in both drivers and constructors details and updated corresponding tests to expect the new symbol.