### PR TITLE
Add interactive menu system with organized command categories

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -112,25 +112,60 @@ A Telegram bot designed to help users manage their F1 Fantasy teams, providing t
 
 ## Available Commands and Inputs
 
+### Command Organization
+
+Commands are organized into logical categories for better usability:
+
+- **❓ Help & Menu**: Essential navigation and help commands
+- **🏎️ Team Management**: Fantasy team optimization and chip management
+- **📊 Analysis & Stats**: Race information and simulation data
+- **🔧 Utilities**: Data management and cache operations
+- **👤 Admin Commands**: Administrative tools (admin-only access)
+
+### Interactive Menu System
+
+- **`/menu`** - Launch the interactive menu with organized command categories for easy navigation
+  - **🏎️ Team Management**: Best teams, current team info, chips selection
+  - **📊 Analysis & Stats**: Next race info, current simulation data
+  - **🔧 Utilities**: Cache management and data operations
+  - **👤 Admin Commands**: Administrative tools (admin only)
+  - **❓ Help**: Direct access to help information
+
+### Help Command
+
+The **`/help`** command displays all available commands organized by the same categories as the interactive menu, providing a comprehensive text-based reference that mirrors the menu structure for consistency.
+
 ### User Commands
 
 All users can access these commands:
 
-- **`/help`** - Show help message with all available commands
+#### Help & Menu
+
+- **`/help`** - Show help message with commands organized by categories
+- **`/menu`** - Show interactive menu with organized command categories
+
+#### Team Management
+
 - **`/best_teams`** - Calculate and display the best possible teams based on your cached data
 - **`/current_team_info`** - Calculate current team info and budget based on your cached data
 - **`/chips`** - Choose a chip to use for the current race (Extra DRS, Wildcard, Limitless)
+
+#### Analysis & Stats
+
+- **`/next_race_info`** - Get comprehensive information about the next F1 race including schedule, weather forecast, historical statistics with qualifying results and race winners, safety data, and track information
+- **`/get_current_simulation`** - Show the current simulation data, name, and last update timestamp
+
+#### Utilities
+
 - **`/print_cache`** - Show the currently cached drivers, constructors, and current team
 - **`/reset_cache`** - Clear all cached data for this chat
-- **`/get_current_simulation`** - Show the current simulation data, name, and last update timestamp
-- **`/next_race_info`** - Get comprehensive information about the next F1 race including schedule, weather forecast, historical statistics with qualifying results and race winners, safety data, and track information
 
 ### Admin Commands
 
 Restricted to authorized administrators:
 
-- **`/trigger_scraping`** - Trigger web scraping for latest F1 Fantasy data
 - **`/load_simulation`** - Load the latest simulation data
+- **`/trigger_scraping`** - Trigger web scraping for latest F1 Fantasy data
 - **`/billing_stats`** - View current month Azure billing statistics with service breakdown
 - **`/get_botfather_commands`** - Get commands formatted for BotFather setup
 

--- a/src/callbackQueryHandler.js
+++ b/src/callbackQueryHandler.js
@@ -16,11 +16,13 @@ const {
   NAME_TO_CODE_MAPPING,
   PHOTO_CALLBACK_TYPE,
   CHIP_CALLBACK_TYPE,
+  MENU_CALLBACK_TYPE,
   WITHOUT_CHIP,
   COMMAND_BEST_TEAMS,
 } = require('./constants');
 
 const { sendLogMessage } = require('./utils');
+const { handleMenuCallback } = require('./commandsHandler/menuHandler');
 
 exports.handleCallbackQuery = async function (bot, query) {
   const callbackType = query.data.split(':')[0];
@@ -30,6 +32,8 @@ exports.handleCallbackQuery = async function (bot, query) {
       return await handlePhotoCallback(bot, query);
     case CHIP_CALLBACK_TYPE:
       return await handleChipCallback(bot, query);
+    case MENU_CALLBACK_TYPE:
+      return await handleMenuCallback(bot, query);
     default:
       await sendLogMessage(bot, `Unknown callback type: ${callbackType}`);
   }

--- a/src/commandsHandler/helpHandler.js
+++ b/src/commandsHandler/helpHandler.js
@@ -1,46 +1,72 @@
 const { isAdminMessage } = require('../utils');
-const {
-  USER_COMMANDS_CONFIG,
-  ADMIN_COMMANDS_CONFIG,
-  COMMAND_BEST_TEAMS,
-} = require('../constants');
+const { MENU_CATEGORIES, COMMAND_BEST_TEAMS } = require('../constants');
 
 async function displayHelpMessage(bot, msg) {
   const chatId = msg.chat.id;
   const isAdmin = isAdminMessage(msg);
 
-  let helpMessage = '*Available Commands:*\n';
-  USER_COMMANDS_CONFIG.forEach((cmd) => {
-    helpMessage += `${cmd.constant.replace(/_/g, '\\_')} - ${
-      cmd.description
-    }\n`;
+  let helpMessage = '*F1 Fantasy Bot - Available Commands*\n\n';
+
+  // Add each menu category section in their natural order
+  Object.values(MENU_CATEGORIES).forEach((category) => {
+    const categorySection = buildCategoryHelpSection(category, isAdmin);
+    if (categorySection) {
+      helpMessage += categorySection;
+    }
   });
-  helpMessage += '\n';
 
-  if (isAdmin) {
-    helpMessage += '*Admin Commands:*\n';
-    ADMIN_COMMANDS_CONFIG.forEach((cmd) => {
-      helpMessage += `${cmd.constant.replace(/_/g, '\\_')} - ${
-        cmd.description
-      }\n`;
-    });
-    helpMessage += '\n';
-  }
-
-  helpMessage +=
-    '*Other Messages:*\n' +
-    '- Send an image (drivers, constructors, or current team screenshot) to automatically extract and cache the relevant data.\n' +
-    '- Send valid JSON data to update your drivers, constructors, and current team cache.\n' +
-    `- Send a number (e.g., 1) to get the required changes to reach that team from your current team (after using ${COMMAND_BEST_TEAMS.replace(
-      /_/g,
-      '\\_'
-    )}).`;
+  // Add other messages section
+  helpMessage += buildOtherMessagesSection();
 
   await bot
     .sendMessage(chatId, helpMessage, { parse_mode: 'Markdown' })
     .catch((err) => console.error('Error sending help message:', err));
 
   return;
+}
+
+/**
+ * Builds help text for a specific menu category
+ * @param {Object} category - The menu category object
+ * @param {boolean} isAdmin - Whether the user is an admin
+ * @returns {string} Formatted help text for the category
+ */
+function buildCategoryHelpSection(category, isAdmin) {
+  // Skip admin-only categories for non-admin users
+  if (category.adminOnly && !isAdmin) {
+    return '';
+  }
+
+  let categorySection = `${category.title}\n`;
+
+  // Filter visible commands for this category
+  const visibleCommands = category.commands.filter((command) => {
+    return !(command.adminOnly && !isAdmin);
+  });
+
+  visibleCommands.forEach((command) => {
+    categorySection += `${command.constant.replace(/_/g, '\\_')} - ${
+      command.description
+    }\n`;
+  });
+
+  return categorySection + '\n';
+}
+
+/**
+ * Builds the "Other Messages" section
+ * @returns {string} Formatted text for other message types
+ */
+function buildOtherMessagesSection() {
+  return (
+    '*Other Messages:*\n' +
+    '- Send an image (drivers, constructors, or current team screenshot) to automatically extract and cache the relevant data.\n' +
+    '- Send valid JSON data to update your drivers, constructors, and current team cache.\n' +
+    `- Send a number (e.g., 1) to get the required changes to reach that team from your current team (after using ${COMMAND_BEST_TEAMS.replace(
+      /_/g,
+      '\\_'
+    )}).`
+  );
 }
 
 module.exports = { displayHelpMessage };

--- a/src/commandsHandler/index.js
+++ b/src/commandsHandler/index.js
@@ -13,6 +13,7 @@ const { sendPrintableCache } = require('./printCacheHandler');
 const { resetCacheForChat } = require('./resetCacheHandler');
 const { handleScrapingTrigger } = require('./scrapingTriggerHandler');
 const { handleBillingStats } = require('./billingStatsHandler');
+const { displayMenuMessage } = require('./menuHandler');
 
 module.exports = {
   handleBestTeamsMessage,
@@ -29,4 +30,5 @@ module.exports = {
   resetCacheForChat,
   handleScrapingTrigger,
   handleBillingStats,
+  displayMenuMessage,
 };

--- a/src/commandsHandler/menuHandler.js
+++ b/src/commandsHandler/menuHandler.js
@@ -47,91 +47,6 @@ const COMMAND_HANDLERS = {
   [COMMAND_BILLING_STATS]: handleBillingStats,
 };
 
-function buildKeyboard(items, buttonBuilder, itemsPerRow = 2) {
-  const keyboard = [];
-
-  for (let i = 0; i < items.length; i += itemsPerRow) {
-    const row = [];
-
-    // Add items to the row up to itemsPerRow limit
-    for (let j = 0; j < itemsPerRow && i + j < items.length; j++) {
-      const item = items[i + j];
-      row.push(buttonBuilder(item));
-    }
-
-    keyboard.push(row);
-  }
-
-  return keyboard;
-}
-
-function buildMainMenuKeyboard(isAdmin) {
-  // Filter visible categories
-  const visibleCategories = Object.values(MENU_CATEGORIES).filter(
-    (category) => {
-      // Skip admin-only categories for non-admin users
-      // Skip categories marked as hideFromMenu
-      return !(category.adminOnly && !isAdmin) && !category.hideFromMenu;
-    }
-  );
-
-  // Build category buttons (2 per row)
-  const keyboard = buildKeyboard(
-    visibleCategories,
-    (category) => ({
-      text: category.title,
-      callback_data: `${MENU_CALLBACK_TYPE}:${MENU_ACTIONS.CATEGORY}:${category.id}`,
-    }),
-    2
-  );
-
-  // Add direct help button
-  keyboard.push([
-    {
-      text: '❓ Help',
-      callback_data: `${MENU_CALLBACK_TYPE}:${MENU_ACTIONS.HELP}`,
-    },
-  ]);
-
-  return keyboard;
-}
-
-function buildCategoryMenuKeyboard(category, isAdmin) {
-  // Filter visible commands
-  const visibleCommands = category.commands.filter((command) => {
-    // Skip admin-only commands for non-admin users
-    return !(command.adminOnly && !isAdmin);
-  });
-
-  // Build command buttons (2 per row)
-  const keyboard = buildKeyboard(
-    visibleCommands,
-    (command) => ({
-      text: command.title,
-      callback_data: `${MENU_CALLBACK_TYPE}:${MENU_ACTIONS.COMMAND}:${command.constant}`,
-    }),
-    2
-  );
-
-  // Add back button
-  keyboard.push([
-    {
-      text: '⬅️ Back to Main Menu',
-      callback_data: `${MENU_CALLBACK_TYPE}:${MENU_ACTIONS.MAIN_MENU}`,
-    },
-  ]);
-
-  return keyboard;
-}
-
-function buildMainMenuMessage() {
-  const menuMessage = '🎯 *F1 Fantasy Bot Menu*\n\nChoose a category:';
-  const tipMessage =
-    menuMessage + `\n\n💡 *Tip:* Use ${COMMAND_HELP} for quick text-based help`;
-
-  return tipMessage;
-}
-
 async function displayMenuMessage(bot, msg) {
   const chatId = msg.chat.id;
   const isAdmin = isAdminMessage(msg);
@@ -181,6 +96,91 @@ async function handleMenuCallback(bot, query) {
   }
 
   await bot.answerCallbackQuery(query.id);
+}
+
+function buildMainMenuMessage() {
+  const menuMessage = '🎯 *F1 Fantasy Bot Menu*\n\nChoose a category:';
+  const tipMessage =
+    menuMessage + `\n\n💡 *Tip:* Use ${COMMAND_HELP} for quick text-based help`;
+
+  return tipMessage;
+}
+
+function buildMainMenuKeyboard(isAdmin) {
+  // Filter visible categories
+  const visibleCategories = Object.values(MENU_CATEGORIES).filter(
+    (category) => {
+      // Skip admin-only categories for non-admin users
+      // Skip categories marked as hideFromMenu
+      return !(category.adminOnly && !isAdmin) && !category.hideFromMenu;
+    }
+  );
+
+  // Build category buttons (2 per row)
+  const keyboard = buildKeyboard(
+    visibleCategories,
+    (category) => ({
+      text: category.title,
+      callback_data: `${MENU_CALLBACK_TYPE}:${MENU_ACTIONS.CATEGORY}:${category.id}`,
+    }),
+    2
+  );
+
+  // Add direct help button
+  keyboard.push([
+    {
+      text: '❓ Help',
+      callback_data: `${MENU_CALLBACK_TYPE}:${MENU_ACTIONS.HELP}`,
+    },
+  ]);
+
+  return keyboard;
+}
+
+function buildKeyboard(items, buttonBuilder, itemsPerRow = 2) {
+  const keyboard = [];
+
+  for (let i = 0; i < items.length; i += itemsPerRow) {
+    const row = [];
+
+    // Add items to the row up to itemsPerRow limit
+    for (let j = 0; j < itemsPerRow && i + j < items.length; j++) {
+      const item = items[i + j];
+      row.push(buttonBuilder(item));
+    }
+
+    keyboard.push(row);
+  }
+
+  return keyboard;
+}
+
+function buildCategoryMenuKeyboard(category, isAdmin) {
+  // Filter visible commands
+  const visibleCommands = category.commands.filter((command) => {
+    // Skip admin-only commands for non-admin users
+    return !(command.adminOnly && !isAdmin);
+  });
+
+  // Build command buttons (2 per row)
+  const keyboard = buildKeyboard(
+    visibleCommands,
+    (command) => ({
+      text: command.title,
+      callback_data: `${MENU_CALLBACK_TYPE}:${MENU_ACTIONS.COMMAND}:${command.constant}`,
+    }),
+    2
+  );
+
+  // Add back button
+  keyboard.push([
+    {
+      text: '⬅️ Back to Main Menu',
+      callback_data: `${MENU_CALLBACK_TYPE}:${MENU_ACTIONS.MAIN_MENU}`,
+    },
+  ]);
+
+  return keyboard;
 }
 
 async function showMainMenu(bot, chatId, messageId, isAdmin) {

--- a/src/commandsHandler/menuHandler.js
+++ b/src/commandsHandler/menuHandler.js
@@ -1,0 +1,298 @@
+const { isAdminMessage } = require('../utils');
+const {
+  MENU_CATEGORIES,
+  MENU_ACTIONS,
+  MENU_CALLBACK_TYPE,
+  COMMAND_BEST_TEAMS,
+  COMMAND_CURRENT_TEAM_INFO,
+  COMMAND_CHIPS,
+  COMMAND_PRINT_CACHE,
+  COMMAND_RESET_CACHE,
+  COMMAND_HELP,
+  COMMAND_TRIGGER_SCRAPING,
+  COMMAND_LOAD_SIMULATION,
+  COMMAND_GET_CURRENT_SIMULATION,
+  COMMAND_GET_BOTFATHER_COMMANDS,
+  COMMAND_NEXT_RACE_INFO,
+  COMMAND_BILLING_STATS,
+} = require('../constants');
+
+// Import command handlers directly to avoid circular dependency
+const { handleBestTeamsMessage } = require('./bestTeamsHandler');
+const { handleChipsMessage } = require('./chipsHandler');
+const { calcCurrentTeamInfo } = require('./currentTeamInfoHandler');
+const { handleGetBotfatherCommands } = require('./getBotfatherCommandsHandler');
+const { handleGetCurrentSimulation } = require('./getCurrentSimulationHandler');
+const { displayHelpMessage } = require('./helpHandler');
+const { handleLoadSimulation } = require('./loadSimulationHandler');
+const { handleNextRaceInfoCommand } = require('./nextRaceInfoHandler');
+const { sendPrintableCache } = require('./printCacheHandler');
+const { resetCacheForChat } = require('./resetCacheHandler');
+const { handleScrapingTrigger } = require('./scrapingTriggerHandler');
+const { handleBillingStats } = require('./billingStatsHandler');
+
+// Map commands to their handler functions
+const COMMAND_HANDLERS = {
+  [COMMAND_BEST_TEAMS]: handleBestTeamsMessage,
+  [COMMAND_CURRENT_TEAM_INFO]: calcCurrentTeamInfo,
+  [COMMAND_CHIPS]: handleChipsMessage,
+  [COMMAND_PRINT_CACHE]: sendPrintableCache,
+  [COMMAND_RESET_CACHE]: resetCacheForChat,
+  [COMMAND_HELP]: displayHelpMessage,
+  [COMMAND_TRIGGER_SCRAPING]: handleScrapingTrigger,
+  [COMMAND_LOAD_SIMULATION]: handleLoadSimulation,
+  [COMMAND_GET_CURRENT_SIMULATION]: handleGetCurrentSimulation,
+  [COMMAND_GET_BOTFATHER_COMMANDS]: handleGetBotfatherCommands,
+  [COMMAND_NEXT_RACE_INFO]: handleNextRaceInfoCommand,
+  [COMMAND_BILLING_STATS]: handleBillingStats,
+};
+
+function buildKeyboard(items, buttonBuilder, itemsPerRow = 2) {
+  const keyboard = [];
+
+  for (let i = 0; i < items.length; i += itemsPerRow) {
+    const row = [];
+
+    // Add items to the row up to itemsPerRow limit
+    for (let j = 0; j < itemsPerRow && i + j < items.length; j++) {
+      const item = items[i + j];
+      row.push(buttonBuilder(item));
+    }
+
+    keyboard.push(row);
+  }
+
+  return keyboard;
+}
+
+function buildMainMenuKeyboard(isAdmin) {
+  // Filter visible categories
+  const visibleCategories = Object.values(MENU_CATEGORIES).filter(
+    (category) => {
+      // Skip admin-only categories for non-admin users
+      // Skip categories marked as hideFromMenu
+      return !(category.adminOnly && !isAdmin) && !category.hideFromMenu;
+    }
+  );
+
+  // Build category buttons (2 per row)
+  const keyboard = buildKeyboard(
+    visibleCategories,
+    (category) => ({
+      text: category.title,
+      callback_data: `${MENU_CALLBACK_TYPE}:${MENU_ACTIONS.CATEGORY}:${category.id}`,
+    }),
+    2
+  );
+
+  // Add direct help button
+  keyboard.push([
+    {
+      text: '❓ Help',
+      callback_data: `${MENU_CALLBACK_TYPE}:${MENU_ACTIONS.HELP}`,
+    },
+  ]);
+
+  return keyboard;
+}
+
+function buildCategoryMenuKeyboard(category, isAdmin) {
+  // Filter visible commands
+  const visibleCommands = category.commands.filter((command) => {
+    // Skip admin-only commands for non-admin users
+    return !(command.adminOnly && !isAdmin);
+  });
+
+  // Build command buttons (2 per row)
+  const keyboard = buildKeyboard(
+    visibleCommands,
+    (command) => ({
+      text: command.title,
+      callback_data: `${MENU_CALLBACK_TYPE}:${MENU_ACTIONS.COMMAND}:${command.constant}`,
+    }),
+    2
+  );
+
+  // Add back button
+  keyboard.push([
+    {
+      text: '⬅️ Back to Main Menu',
+      callback_data: `${MENU_CALLBACK_TYPE}:${MENU_ACTIONS.MAIN_MENU}`,
+    },
+  ]);
+
+  return keyboard;
+}
+
+function buildMainMenuMessage() {
+  const menuMessage = '🎯 *F1 Fantasy Bot Menu*\n\nChoose a category:';
+  const tipMessage =
+    menuMessage + `\n\n💡 *Tip:* Use ${COMMAND_HELP} for quick text-based help`;
+
+  return tipMessage;
+}
+
+async function displayMenuMessage(bot, msg) {
+  const chatId = msg.chat.id;
+  const isAdmin = isAdminMessage(msg);
+
+  const message = buildMainMenuMessage();
+  const keyboard = buildMainMenuKeyboard(isAdmin);
+
+  await bot
+    .sendMessage(chatId, message, {
+      parse_mode: 'Markdown',
+      reply_markup: {
+        inline_keyboard: keyboard,
+      },
+    })
+    .catch((err) => console.error('Error sending menu message:', err));
+}
+
+async function handleMenuCallback(bot, query) {
+  const chatId = query.message.chat.id;
+  const messageId = query.message.message_id;
+  const isAdmin = isAdminMessage({ chat: { id: chatId } });
+
+  const [, action, data] = query.data.split(':');
+
+  switch (action) {
+    case MENU_ACTIONS.MAIN_MENU:
+      await showMainMenu(bot, chatId, messageId, isAdmin);
+      break;
+    case MENU_ACTIONS.CATEGORY:
+      await showCategoryMenu(bot, chatId, messageId, data, isAdmin);
+      break;
+    case MENU_ACTIONS.COMMAND:
+      await executeCommand(bot, query, data);
+
+      return; // Don't answer callback query here as command handlers might do it
+    case MENU_ACTIONS.HELP:
+      await executeHelpCommand(bot, query);
+
+      return; // Don't answer callback query here
+    default:
+      await bot.answerCallbackQuery(query.id, {
+        text: 'Unknown menu action',
+        show_alert: true,
+      });
+
+      return;
+  }
+
+  await bot.answerCallbackQuery(query.id);
+}
+
+async function showMainMenu(bot, chatId, messageId, isAdmin) {
+  const message = buildMainMenuMessage();
+  const keyboard = buildMainMenuKeyboard(isAdmin);
+
+  await bot.editMessageText(message, {
+    chat_id: chatId,
+    message_id: messageId,
+    parse_mode: 'Markdown',
+    reply_markup: {
+      inline_keyboard: keyboard,
+    },
+  });
+}
+
+async function showCategoryMenu(bot, chatId, messageId, categoryId, isAdmin) {
+  const category = Object.values(MENU_CATEGORIES).find(
+    (cat) => cat.id === categoryId
+  );
+
+  if (!category) {
+    console.error('Category not found:', categoryId);
+
+    return;
+  }
+
+  const menuMessage = `${category.title}\n\n${category.description}\n\nChoose a command:`;
+  const keyboard = buildCategoryMenuKeyboard(category, isAdmin);
+
+  await bot.editMessageText(menuMessage, {
+    chat_id: chatId,
+    message_id: messageId,
+    parse_mode: 'Markdown',
+    reply_markup: {
+      inline_keyboard: keyboard,
+    },
+  });
+}
+
+async function executeCommand(bot, query, command) {
+  const chatId = query.message.chat.id;
+  const messageId = query.message.message_id;
+
+  // Create a message object for the command handlers
+  const msg = {
+    chat: { id: chatId },
+    text: command,
+    message_id: messageId,
+  };
+
+  // Find and execute the command handler
+  const handler = COMMAND_HANDLERS[command];
+  if (handler) {
+    try {
+      // Answer the callback query first
+      await bot.answerCallbackQuery(query.id, {
+        text: `Executing ${command}...`,
+      });
+
+      // Execute the command based on handler parameter patterns
+      if (command === COMMAND_PRINT_CACHE || command === COMMAND_RESET_CACHE) {
+        // Handlers that expect (chatId, bot) parameters
+        await handler(chatId, bot);
+      } else if (
+        command === COMMAND_BEST_TEAMS ||
+        command === COMMAND_CURRENT_TEAM_INFO ||
+        command === COMMAND_NEXT_RACE_INFO
+      ) {
+        // Handlers that expect (bot, chatId) parameters
+        await handler(bot, chatId);
+      } else {
+        // Handlers that expect (bot, msg) parameters
+        await handler(bot, msg);
+      }
+    } catch (error) {
+      console.error(`Error executing command ${command}:`, error);
+      await bot.answerCallbackQuery(query.id, {
+        text: 'Error executing command',
+        show_alert: true,
+      });
+    }
+  } else {
+    await bot.answerCallbackQuery(query.id, {
+      text: 'Command not found',
+      show_alert: true,
+    });
+  }
+}
+
+async function executeHelpCommand(bot, query) {
+  const chatId = query.message.chat.id;
+  const mockMsg = {
+    chat: { id: chatId },
+    text: COMMAND_HELP,
+  };
+
+  try {
+    await bot.answerCallbackQuery(query.id, {
+      text: 'Showing help...',
+    });
+    await displayHelpMessage(bot, mockMsg);
+  } catch (error) {
+    console.error('Error executing help command:', error);
+    await bot.answerCallbackQuery(query.id, {
+      text: 'Error showing help',
+      show_alert: true,
+    });
+  }
+}
+
+module.exports = {
+  displayMenuMessage,
+  handleMenuCallback,
+};

--- a/src/commandsHandler/menuHandler.test.js
+++ b/src/commandsHandler/menuHandler.test.js
@@ -1,0 +1,401 @@
+const { displayMenuMessage, handleMenuCallback } = require('./menuHandler');
+const { MENU_CALLBACK_TYPE, MENU_ACTIONS } = require('../constants');
+
+// Mock the utils function
+jest.mock('../utils', () => ({
+  isAdminMessage: jest.fn(),
+}));
+
+// Mock all command handlers individually
+jest.mock('./bestTeamsHandler', () => ({
+  handleBestTeamsMessage: jest.fn(),
+}));
+jest.mock('./chipsHandler', () => ({
+  handleChipsMessage: jest.fn(),
+}));
+jest.mock('./currentTeamInfoHandler', () => ({
+  calcCurrentTeamInfo: jest.fn(),
+}));
+jest.mock('./getBotfatherCommandsHandler', () => ({
+  handleGetBotfatherCommands: jest.fn(),
+}));
+jest.mock('./getCurrentSimulationHandler', () => ({
+  handleGetCurrentSimulation: jest.fn(),
+}));
+jest.mock('./helpHandler', () => ({
+  displayHelpMessage: jest.fn(),
+}));
+jest.mock('./loadSimulationHandler', () => ({
+  handleLoadSimulation: jest.fn(),
+}));
+jest.mock('./nextRaceInfoHandler', () => ({
+  handleNextRaceInfoCommand: jest.fn(),
+}));
+jest.mock('./printCacheHandler', () => ({
+  sendPrintableCache: jest.fn(),
+}));
+jest.mock('./resetCacheHandler', () => ({
+  resetCacheForChat: jest.fn(),
+}));
+jest.mock('./scrapingTriggerHandler', () => ({
+  handleScrapingTrigger: jest.fn(),
+}));
+jest.mock('./billingStatsHandler', () => ({
+  handleBillingStats: jest.fn(),
+}));
+
+const { isAdminMessage } = require('../utils');
+
+// Import the mocked handlers
+const { handleBestTeamsMessage } = require('./bestTeamsHandler');
+const { displayHelpMessage } = require('./helpHandler');
+const { sendPrintableCache } = require('./printCacheHandler');
+const { resetCacheForChat } = require('./resetCacheHandler');
+
+describe('Menu Handler', () => {
+  let mockBot;
+  let mockMsg;
+  let mockQuery;
+
+  beforeEach(() => {
+    mockBot = {
+      sendMessage: jest.fn().mockResolvedValue({}),
+      editMessageText: jest.fn().mockResolvedValue({}),
+      answerCallbackQuery: jest.fn().mockResolvedValue({}),
+    };
+
+    mockMsg = {
+      chat: { id: 123 },
+      text: '/menu',
+    };
+
+    mockQuery = {
+      id: 'callback_query_id',
+      data: '',
+      message: {
+        chat: { id: 123 },
+        message_id: 456,
+      },
+    };
+
+    jest.clearAllMocks();
+  });
+
+  describe('displayMenuMessage', () => {
+    it('should display menu for regular user', async () => {
+      isAdminMessage.mockReturnValue(false);
+
+      await displayMenuMessage(mockBot, mockMsg);
+
+      expect(mockBot.sendMessage).toHaveBeenCalledWith(
+        123,
+        expect.stringContaining('🎯 *F1 Fantasy Bot Menu*'),
+        expect.objectContaining({
+          parse_mode: 'Markdown',
+          reply_markup: expect.objectContaining({
+            inline_keyboard: expect.arrayContaining([
+              expect.arrayContaining([
+                expect.objectContaining({
+                  text: '🏎️ Team Management',
+                  callback_data: `${MENU_CALLBACK_TYPE}:${MENU_ACTIONS.CATEGORY}:team_management`,
+                }),
+              ]),
+              expect.arrayContaining([
+                expect.objectContaining({
+                  text: '📊 Analysis & Stats',
+                  callback_data: `${MENU_CALLBACK_TYPE}:${MENU_ACTIONS.CATEGORY}:analysis_stats`,
+                }),
+              ]),
+              expect.arrayContaining([
+                expect.objectContaining({
+                  text: '🔧 Utilities',
+                  callback_data: `${MENU_CALLBACK_TYPE}:${MENU_ACTIONS.CATEGORY}:utilities`,
+                }),
+              ]),
+              expect.arrayContaining([
+                expect.objectContaining({
+                  text: '❓ Help',
+                  callback_data: `${MENU_CALLBACK_TYPE}:${MENU_ACTIONS.HELP}`,
+                }),
+              ]),
+            ]),
+          }),
+        })
+      );
+    });
+
+    it('should display menu with admin commands for admin user', async () => {
+      isAdminMessage.mockReturnValue(true);
+
+      await displayMenuMessage(mockBot, mockMsg);
+
+      expect(mockBot.sendMessage).toHaveBeenCalledWith(
+        123,
+        expect.stringContaining('🎯 *F1 Fantasy Bot Menu*'),
+        expect.objectContaining({
+          reply_markup: expect.objectContaining({
+            inline_keyboard: expect.arrayContaining([
+              expect.arrayContaining([
+                expect.objectContaining({
+                  text: '👤 Admin Commands',
+                  callback_data: `${MENU_CALLBACK_TYPE}:${MENU_ACTIONS.CATEGORY}:admin_commands`,
+                }),
+              ]),
+            ]),
+          }),
+        })
+      );
+    });
+
+    it('should handle sendMessage error gracefully', async () => {
+      isAdminMessage.mockReturnValue(false);
+      mockBot.sendMessage.mockRejectedValue(new Error('Network error'));
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+
+      await displayMenuMessage(mockBot, mockMsg);
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        'Error sending menu message:',
+        expect.any(Error)
+      );
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe('handleMenuCallback', () => {
+    it('should handle main menu callback', async () => {
+      isAdminMessage.mockReturnValue(false);
+      mockQuery.data = `${MENU_CALLBACK_TYPE}:${MENU_ACTIONS.MAIN_MENU}`;
+
+      await handleMenuCallback(mockBot, mockQuery);
+
+      expect(mockBot.editMessageText).toHaveBeenCalledWith(
+        expect.stringContaining('🎯 *F1 Fantasy Bot Menu*'),
+        expect.objectContaining({
+          chat_id: 123,
+          message_id: 456,
+          parse_mode: 'Markdown',
+          reply_markup: expect.objectContaining({
+            inline_keyboard: expect.any(Array),
+          }),
+        })
+      );
+      expect(mockBot.answerCallbackQuery).toHaveBeenCalledWith(
+        'callback_query_id'
+      );
+    });
+
+    it('should handle category callback', async () => {
+      isAdminMessage.mockReturnValue(false);
+      mockQuery.data = `${MENU_CALLBACK_TYPE}:${MENU_ACTIONS.CATEGORY}:team_management`;
+
+      await handleMenuCallback(mockBot, mockQuery);
+
+      expect(mockBot.editMessageText).toHaveBeenCalledWith(
+        expect.stringContaining('🏎️ Team Management'),
+        expect.objectContaining({
+          chat_id: 123,
+          message_id: 456,
+          parse_mode: 'Markdown',
+          reply_markup: expect.objectContaining({
+            inline_keyboard: expect.arrayContaining([
+              expect.arrayContaining([
+                expect.objectContaining({
+                  text: '🏆 Best Teams',
+                }),
+              ]),
+              expect.arrayContaining([
+                expect.objectContaining({
+                  text: '⬅️ Back to Main Menu',
+                }),
+              ]),
+            ]),
+          }),
+        })
+      );
+      expect(mockBot.answerCallbackQuery).toHaveBeenCalledWith(
+        'callback_query_id'
+      );
+    });
+
+    it('should handle help callback', async () => {
+      mockQuery.data = `${MENU_CALLBACK_TYPE}:${MENU_ACTIONS.HELP}`;
+
+      await handleMenuCallback(mockBot, mockQuery);
+
+      expect(mockBot.answerCallbackQuery).toHaveBeenCalledWith(
+        'callback_query_id',
+        {
+          text: 'Showing help...',
+        }
+      );
+      expect(displayHelpMessage).toHaveBeenCalledWith(
+        mockBot,
+        expect.objectContaining({
+          chat: { id: 123 },
+          text: '/help',
+        })
+      );
+    });
+
+    it('should handle command callback', async () => {
+      mockQuery.data = `${MENU_CALLBACK_TYPE}:${MENU_ACTIONS.COMMAND}:/best_teams`;
+
+      await handleMenuCallback(mockBot, mockQuery);
+
+      expect(mockBot.answerCallbackQuery).toHaveBeenCalledWith(
+        'callback_query_id',
+        {
+          text: 'Executing /best_teams...',
+        }
+      );
+      expect(handleBestTeamsMessage).toHaveBeenCalledWith(mockBot, 123);
+    });
+
+    it('should handle print cache command callback', async () => {
+      mockQuery.data = `${MENU_CALLBACK_TYPE}:${MENU_ACTIONS.COMMAND}:/print_cache`;
+
+      await handleMenuCallback(mockBot, mockQuery);
+
+      expect(mockBot.answerCallbackQuery).toHaveBeenCalledWith(
+        'callback_query_id',
+        {
+          text: 'Executing /print_cache...',
+        }
+      );
+      expect(sendPrintableCache).toHaveBeenCalledWith(123, mockBot);
+    });
+
+    it('should handle reset cache command callback', async () => {
+      mockQuery.data = `${MENU_CALLBACK_TYPE}:${MENU_ACTIONS.COMMAND}:/reset_cache`;
+
+      await handleMenuCallback(mockBot, mockQuery);
+
+      expect(mockBot.answerCallbackQuery).toHaveBeenCalledWith(
+        'callback_query_id',
+        {
+          text: 'Executing /reset_cache...',
+        }
+      );
+      expect(resetCacheForChat).toHaveBeenCalledWith(123, mockBot);
+    });
+
+    it('should handle unknown callback action', async () => {
+      mockQuery.data = `${MENU_CALLBACK_TYPE}:unknown_action`;
+
+      await handleMenuCallback(mockBot, mockQuery);
+
+      expect(mockBot.answerCallbackQuery).toHaveBeenCalledWith(
+        'callback_query_id',
+        {
+          text: 'Unknown menu action',
+          show_alert: true,
+        }
+      );
+    });
+
+    it('should handle unknown category', async () => {
+      mockQuery.data = `${MENU_CALLBACK_TYPE}:${MENU_ACTIONS.CATEGORY}:unknown_category`;
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+
+      await handleMenuCallback(mockBot, mockQuery);
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        'Category not found:',
+        'unknown_category'
+      );
+      expect(mockBot.answerCallbackQuery).toHaveBeenCalledWith(
+        'callback_query_id'
+      );
+      consoleSpy.mockRestore();
+    });
+
+    it('should handle command execution error', async () => {
+      handleBestTeamsMessage.mockRejectedValue(new Error('Command error'));
+      mockQuery.data = `${MENU_CALLBACK_TYPE}:${MENU_ACTIONS.COMMAND}:/best_teams`;
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+
+      await handleMenuCallback(mockBot, mockQuery);
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        'Error executing command /best_teams:',
+        expect.any(Error)
+      );
+      expect(mockBot.answerCallbackQuery).toHaveBeenCalledWith(
+        'callback_query_id',
+        {
+          text: 'Error executing command',
+          show_alert: true,
+        }
+      );
+      consoleSpy.mockRestore();
+    });
+
+    it('should handle help command execution error', async () => {
+      displayHelpMessage.mockRejectedValue(new Error('Help error'));
+      mockQuery.data = `${MENU_CALLBACK_TYPE}:${MENU_ACTIONS.HELP}`;
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+
+      await handleMenuCallback(mockBot, mockQuery);
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        'Error executing help command:',
+        expect.any(Error)
+      );
+      expect(mockBot.answerCallbackQuery).toHaveBeenCalledWith(
+        'callback_query_id',
+        {
+          text: 'Error showing help',
+          show_alert: true,
+        }
+      );
+      consoleSpy.mockRestore();
+    });
+
+    it('should handle unknown command', async () => {
+      mockQuery.data = `${MENU_CALLBACK_TYPE}:${MENU_ACTIONS.COMMAND}:/unknown_command`;
+
+      await handleMenuCallback(mockBot, mockQuery);
+
+      expect(mockBot.answerCallbackQuery).toHaveBeenCalledWith(
+        'callback_query_id',
+        {
+          text: 'Command not found',
+          show_alert: true,
+        }
+      );
+    });
+
+    it('should filter admin commands for regular users in category view', async () => {
+      isAdminMessage.mockReturnValue(false);
+      mockQuery.data = `${MENU_CALLBACK_TYPE}:${MENU_ACTIONS.CATEGORY}:team_management`;
+
+      await handleMenuCallback(mockBot, mockQuery);
+
+      const editCall = mockBot.editMessageText.mock.calls[0][1];
+      const keyboard = editCall.reply_markup.inline_keyboard;
+
+      // Should not include Load Simulation button for regular users (it's now in admin commands)
+      const hasLoadSimulation = keyboard.some((row) =>
+        row.some((button) => button.text === '📋 Load Simulation')
+      );
+      expect(hasLoadSimulation).toBe(false);
+    });
+
+    it('should include admin commands for admin users in category view', async () => {
+      isAdminMessage.mockReturnValue(true);
+      mockQuery.data = `${MENU_CALLBACK_TYPE}:${MENU_ACTIONS.CATEGORY}:admin_commands`;
+
+      await handleMenuCallback(mockBot, mockQuery);
+
+      const editCall = mockBot.editMessageText.mock.calls[0][1];
+      const keyboard = editCall.reply_markup.inline_keyboard;
+
+      // Should include Load Simulation button for admin users in admin commands category
+      const hasLoadSimulation = keyboard.some((row) =>
+        row.some((button) => button.text === '📋 Load Simulation')
+      );
+      expect(hasLoadSimulation).toBe(true);
+    });
+  });
+});

--- a/src/constants.js
+++ b/src/constants.js
@@ -13,6 +13,7 @@ exports.WITHOUT_CHIP = 'WITHOUT_CHIP';
 
 exports.PHOTO_CALLBACK_TYPE = 'PHOTO';
 exports.CHIP_CALLBACK_TYPE = 'CHIP';
+exports.MENU_CALLBACK_TYPE = 'MENU';
 
 exports.COMMAND_BEST_TEAMS = '/best_teams';
 exports.COMMAND_CURRENT_TEAM_INFO = '/current_team_info';
@@ -26,62 +27,157 @@ exports.COMMAND_GET_CURRENT_SIMULATION = '/get_current_simulation';
 exports.COMMAND_GET_BOTFATHER_COMMANDS = '/get_botfather_commands';
 exports.COMMAND_NEXT_RACE_INFO = '/next_race_info';
 exports.COMMAND_BILLING_STATS = '/billing_stats';
+exports.COMMAND_MENU = '/menu';
 
-exports.USER_COMMANDS_CONFIG = [
-  {
-    constant: exports.COMMAND_HELP,
-    description: 'Show this help message.',
+// Menu configuration for interactive menu command
+exports.MENU_CATEGORIES = {
+  HELP_MENU: {
+    id: 'help_menu',
+    title: '❓ Help & Menu',
+    description: 'Help and navigation commands',
+    hideFromMenu: true, // Don't show in interactive menu
+    commands: [
+      {
+        constant: exports.COMMAND_HELP,
+        title: '❓ Help',
+        description: 'Show this help message.',
+      },
+      {
+        constant: exports.COMMAND_MENU,
+        title: '📱 Menu',
+        description: 'Show interactive menu with all available commands.',
+      },
+    ],
   },
-  {
-    constant: exports.COMMAND_BEST_TEAMS,
-    description:
-      'Calculate and display the best possible teams based on your cached data.',
+  TEAM_MANAGEMENT: {
+    id: 'team_management',
+    title: '🏎️ Team Management',
+    description: 'Manage and optimize your F1 Fantasy team',
+    commands: [
+      {
+        constant: exports.COMMAND_BEST_TEAMS,
+        title: '🏆 Best Teams',
+        description:
+          'Calculate and display the best possible teams based on your cached data',
+      },
+      {
+        constant: exports.COMMAND_CURRENT_TEAM_INFO,
+        title: '👥 Current Team Info',
+        description:
+          'Calculate the current team info based on your cached data',
+      },
+      {
+        constant: exports.COMMAND_CHIPS,
+        title: '🎯 Chips Selection',
+        description: 'Choose a chip to use for the current race',
+      },
+    ],
   },
-  {
-    constant: exports.COMMAND_CURRENT_TEAM_INFO,
-    description: 'Calculate the current team info based on your cached data.',
+  ANALYSIS_STATS: {
+    id: 'analysis_stats',
+    title: '📊 Analysis & Stats',
+    description: 'View race information and performance data',
+    commands: [
+      {
+        constant: exports.COMMAND_NEXT_RACE_INFO,
+        title: '🏁 Next Race Info',
+        description: 'Get detailed information about the next F1 race',
+      },
+      {
+        constant: exports.COMMAND_GET_CURRENT_SIMULATION,
+        title: '📈 Current Simulation',
+        description: 'Show the current simulation data and name',
+      },
+    ],
   },
-  {
-    constant: exports.COMMAND_CHIPS,
-    description: 'choose a chip to use for the current race.',
+  UTILITIES: {
+    id: 'utilities',
+    title: '🔧 Utilities',
+    description: 'Data management and maintenance tools',
+    commands: [
+      {
+        constant: exports.COMMAND_PRINT_CACHE,
+        title: '📄 Print Cache',
+        description:
+          'Show the currently cached drivers, constructors, and current team',
+      },
+      {
+        constant: exports.COMMAND_RESET_CACHE,
+        title: '🗑️ Reset Cache',
+        description: 'Clear all cached data for this chat',
+      },
+    ],
   },
-  {
-    constant: exports.COMMAND_PRINT_CACHE,
-    description:
-      'Show the currently cached drivers, constructors, and current team.',
+  ADMIN_COMMANDS: {
+    id: 'admin_commands',
+    title: '👤 Admin Commands',
+    description: 'Administrative tools and functions',
+    adminOnly: true,
+    commands: [
+      {
+        constant: exports.COMMAND_LOAD_SIMULATION,
+        title: '📋 Load Simulation',
+        description: 'Load latest simulation data',
+      },
+      {
+        constant: exports.COMMAND_TRIGGER_SCRAPING,
+        title: '🔄 Trigger Scraping',
+        description: 'Trigger web scraping for latest F1 Fantasy data',
+      },
+      {
+        constant: exports.COMMAND_GET_BOTFATHER_COMMANDS,
+        title: '🤖 BotFather Commands',
+        description: 'Get commands for BotFather setup',
+      },
+      {
+        constant: exports.COMMAND_BILLING_STATS,
+        title: '💰 Billing Stats',
+        description: 'Get Azure billing statistics for the current month',
+      },
+    ],
   },
-  {
-    constant: exports.COMMAND_RESET_CACHE,
-    description: 'Clear all cached data for this chat.',
-  },
-  {
-    constant: exports.COMMAND_GET_CURRENT_SIMULATION,
-    description: 'Show the current simulation data and name.',
-  },
-  {
-    constant: exports.COMMAND_NEXT_RACE_INFO,
-    description: 'Get detailed information about the next F1 race.',
-  },
-];
+};
 
-exports.ADMIN_COMMANDS_CONFIG = [
-  {
-    constant: exports.COMMAND_TRIGGER_SCRAPING,
-    description: 'Trigger web scraping for latest F1 Fantasy data.',
-  },
-  {
-    constant: exports.COMMAND_LOAD_SIMULATION,
-    description: 'load latest simulation.',
-  },
-  {
-    constant: exports.COMMAND_GET_BOTFATHER_COMMANDS,
-    description: 'Get commands for BotFather.',
-  },
-  {
-    constant: exports.COMMAND_BILLING_STATS,
-    description: 'Get Azure billing statistics for the current month.',
-  },
-];
+// Generate USER_COMMANDS_CONFIG from MENU_CATEGORIES
+function generateUserCommandsConfig() {
+  const commands = [];
+
+  // Add all non-admin commands from menu categories (including help/menu)
+  Object.values(exports.MENU_CATEGORIES).forEach((category) => {
+    if (!category.adminOnly) {
+      category.commands.forEach((command) => {
+        commands.push({
+          constant: command.constant,
+          description: command.description,
+        });
+      });
+    }
+  });
+
+  return commands;
+}
+
+// Generate ADMIN_COMMANDS_CONFIG from MENU_CATEGORIES
+function generateAdminCommandsConfig() {
+  const commands = [];
+
+  // Add all admin commands from menu categories
+  Object.values(exports.MENU_CATEGORIES).forEach((category) => {
+    if (category.adminOnly) {
+      category.commands.forEach((command) => {
+        commands.push({
+          constant: command.constant,
+          description: command.description,
+        });
+      });
+    }
+  });
+
+  return commands;
+}
+
+exports.USER_COMMANDS_CONFIG = generateUserCommandsConfig();
+exports.ADMIN_COMMANDS_CONFIG = generateAdminCommandsConfig();
 
 exports.NAME_TO_CODE_DRIVERS_MAPPING = {
   'o. piastri': 'PIA',
@@ -124,4 +220,12 @@ exports.NAME_TO_CODE_CONSTRUCTORS_MAPPING = {
 exports.NAME_TO_CODE_MAPPING = {
   ...exports.NAME_TO_CODE_DRIVERS_MAPPING,
   ...exports.NAME_TO_CODE_CONSTRUCTORS_MAPPING,
+};
+
+// Menu callback actions
+exports.MENU_ACTIONS = {
+  MAIN_MENU: 'main_menu',
+  CATEGORY: 'category',
+  COMMAND: 'command',
+  HELP: 'help',
 };

--- a/src/textMessageHandler.js
+++ b/src/textMessageHandler.js
@@ -14,6 +14,7 @@ const {
   handleGetBotfatherCommands,
   handleNextRaceInfoCommand,
   handleBillingStats,
+  displayMenuMessage,
 } = require('./commandsHandler');
 
 // Import constants
@@ -30,6 +31,7 @@ const {
   COMMAND_GET_BOTFATHER_COMMANDS,
   COMMAND_NEXT_RACE_INFO,
   COMMAND_BILLING_STATS,
+  COMMAND_MENU,
 } = require('./constants');
 
 exports.handleTextMessage = async function (bot, msg) {
@@ -68,6 +70,8 @@ exports.handleTextMessage = async function (bot, msg) {
       return await handleNextRaceInfoCommand(bot, chatId);
     case msg.text === COMMAND_BILLING_STATS:
       return await handleBillingStats(bot, msg);
+    case msg.text === COMMAND_MENU:
+      return await displayMenuMessage(bot, msg);
     default:
       handleJsonMessage(bot, msg, chatId);
       break;


### PR DESCRIPTION
- Add new /menu command with organized command categories
- Implement menu handler with callback query support
- Restructure commands into logical categories (Team Management, Analysis & Stats, Utilities, Admin Commands)
- Add comprehensive menu navigation with back/main menu options
- Update help command to display organized command structure
- Add menu callback type and actions constants
- Integrate menu handler with existing callback query system
- Add extensive test coverage for menu functionality
- Update README with detailed menu documentation and command organization

Categories:
- 🏎️ Team Management: best teams, current team info, chips
- 📊 Analysis & Stats: race info, simulation data
- 🔧 Utilities: cache management
- 👤 Admin Commands: scraping, billing, botfather commands
- ❓ Help & Menu: navigation and help