### PR TITLE
Add contact callback integration

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -130,6 +130,7 @@ Commands are organized into logical categories for better usability:
   - **🔧 Utilities**: Cache management and data operations
   - **👤 Admin Commands**: Administrative tools (admin only)
   - **❓ Help**: Direct access to help information
+  - **✉️ Contact Us**: Send a message to the bot admins
 
 ### Help Command
 
@@ -143,6 +144,7 @@ All users can access these commands:
 
 - **`/help`** - Show help message with commands organized by categories
 - **`/menu`** - Show interactive menu with organized command categories
+- **`/contact_us`** - Send a message to the bot admins
 
 #### Team Management
 

--- a/src/callbackQueryHandler.js
+++ b/src/callbackQueryHandler.js
@@ -17,12 +17,14 @@ const {
   PHOTO_CALLBACK_TYPE,
   CHIP_CALLBACK_TYPE,
   MENU_CALLBACK_TYPE,
+  CONTACT_CALLBACK_TYPE,
   WITHOUT_CHIP,
   COMMAND_BEST_TEAMS,
 } = require('./constants');
 
 const { sendLogMessage } = require('./utils');
 const { handleMenuCallback } = require('./commandsHandler/menuHandler');
+const { handleContactCallback } = require('./commandsHandler/contactUsHandler');
 
 exports.handleCallbackQuery = async function (bot, query) {
   const callbackType = query.data.split(':')[0];
@@ -34,6 +36,8 @@ exports.handleCallbackQuery = async function (bot, query) {
       return await handleChipCallback(bot, query);
     case MENU_CALLBACK_TYPE:
       return await handleMenuCallback(bot, query);
+    case CONTACT_CALLBACK_TYPE:
+      return await handleContactCallback(bot, query);
     default:
       await sendLogMessage(bot, `Unknown callback type: ${callbackType}`);
   }

--- a/src/callbackQueryHandler.test.js
+++ b/src/callbackQueryHandler.test.js
@@ -9,6 +9,7 @@ const {
   WILDCARD_CHIP,
   LIMITLESS_CHIP,
   WITHOUT_CHIP,
+  CONTACT_CALLBACK_TYPE,
 } = require('./constants');
 const { extractJsonDataFromPhotos } = require('./jsonDataExtraction');
 const cache = require('./cache');
@@ -49,6 +50,9 @@ jest.mock('./cache', () => ({
   bestTeamsCache: {},
   selectedChipCache: {},
   getPrintableCache: jest.fn(),
+}));
+jest.mock('./commandsHandler/contactUsHandler', () => ({
+  handleContactCallback: jest.fn(),
 }));
 
 describe('handleCallbackQuery', () => {
@@ -341,6 +345,22 @@ describe('handleCallbackQuery', () => {
         expect.stringContaining('rerun /best_teams command'),
         expect.objectContaining({ chat_id: chatId, message_id: messageId })
       );
+    });
+  });
+
+  describe('contact callback handling', () => {
+    it('should forward to handleContactCallback', async () => {
+      const contactQuery = {
+        message: { chat: { id: chatId }, message_id: messageId },
+        data: `${CONTACT_CALLBACK_TYPE}:start`,
+        id: 'contactId',
+      };
+
+      const { handleContactCallback } = require('./commandsHandler/contactUsHandler');
+
+      await handleCallbackQuery(bot, contactQuery);
+
+      expect(handleContactCallback).toHaveBeenCalledWith(bot, contactQuery);
     });
   });
 

--- a/src/commandsHandler/contactUsHandler.js
+++ b/src/commandsHandler/contactUsHandler.js
@@ -1,0 +1,61 @@
+const { sendMessageToAdmins, getChatName } = require('../utils');
+const { CONTACT_CALLBACK_TYPE } = require('../constants');
+
+// Track pending contact requests by chatId -> messageId
+const awaitingContactMessages = {};
+
+async function handleContactUsCommand(bot, msg) {
+  const chatId = msg.chat.id;
+  await bot.sendMessage(chatId, '✉️ Would you like to send a message to the bot admins?', {
+    reply_markup: {
+      inline_keyboard: [
+        [
+          {
+            text: 'Write Message',
+            callback_data: `${CONTACT_CALLBACK_TYPE}:start`,
+          },
+        ],
+      ],
+    },
+  });
+}
+
+async function handleContactCallback(bot, query) {
+  const chatId = query.message.chat.id;
+  const sent = await bot.sendMessage(chatId, 'Please write your message for the admins:', {
+    reply_markup: { force_reply: true },
+  });
+
+  awaitingContactMessages[chatId] = sent.message_id;
+  await bot.answerCallbackQuery(query.id);
+}
+
+async function processContactUsResponse(bot, msg) {
+  const chatId = msg.chat.id;
+  const expectedId = awaitingContactMessages[chatId];
+
+  if (
+    expectedId &&
+    msg.reply_to_message &&
+    msg.reply_to_message.message_id === expectedId
+  ) {
+    const chatName = getChatName(msg);
+    await sendMessageToAdmins(
+      bot,
+      `Contact from ${chatName} (${chatId}):\n${msg.text}`
+    );
+    await bot.sendMessage(chatId, 'Your message was sent to the admins. Thank you!');
+    delete awaitingContactMessages[chatId];
+
+    return true;
+  }
+
+  return false;
+}
+
+module.exports = {
+  handleContactUsCommand,
+  handleContactCallback,
+  processContactUsResponse,
+  awaitingContactMessages,
+};

--- a/src/commandsHandler/contactUsHandler.test.js
+++ b/src/commandsHandler/contactUsHandler.test.js
@@ -1,0 +1,74 @@
+const {
+  handleContactUsCommand,
+  handleContactCallback,
+  processContactUsResponse,
+  awaitingContactMessages,
+} = require('./contactUsHandler');
+const { sendMessageToAdmins, getChatName } = require('../utils');
+
+jest.mock('../utils', () => ({
+  sendMessageToAdmins: jest.fn(),
+  getChatName: jest.fn().mockReturnValue('User'),
+}));
+
+describe('contactUsHandler', () => {
+const botMock = {
+  sendMessage: jest.fn().mockResolvedValue({ message_id: 1 }),
+  answerCallbackQuery: jest.fn().mockResolvedValue(),
+};
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    Object.keys(awaitingContactMessages).forEach((key) => delete awaitingContactMessages[key]);
+  });
+
+  it('handleContactUsCommand sends button to start contact flow', async () => {
+    const msg = { chat: { id: 123 } };
+
+    await handleContactUsCommand(botMock, msg);
+
+    expect(botMock.sendMessage).toHaveBeenCalledWith(123, expect.any(String), {
+      reply_markup: expect.objectContaining({ inline_keyboard: expect.any(Array) }),
+    });
+  });
+
+  it('handleContactCallback sends force reply and stores message id', async () => {
+    const query = { message: { chat: { id: 123 } }, id: 'cbid' };
+
+    await handleContactCallback(botMock, query);
+
+    expect(botMock.sendMessage).toHaveBeenCalledWith(123, expect.any(String), {
+      reply_markup: { force_reply: true },
+    });
+    expect(botMock.answerCallbackQuery).toHaveBeenCalledWith('cbid');
+    expect(awaitingContactMessages[123]).toBe(1);
+  });
+
+  it('processContactUsResponse forwards message when reply matches', async () => {
+    awaitingContactMessages[123] = 1;
+    const msg = { chat: { id: 123 }, text: 'hi', reply_to_message: { message_id: 1 } };
+
+    const res = await processContactUsResponse(botMock, msg);
+
+    expect(res).toBe(true);
+    expect(sendMessageToAdmins).toHaveBeenCalledWith(
+      botMock,
+      expect.stringContaining('hi')
+    );
+    expect(botMock.sendMessage).toHaveBeenCalledWith(
+      123,
+      expect.any(String)
+    );
+    expect(awaitingContactMessages[123]).toBeUndefined();
+  });
+
+  it('processContactUsResponse returns false for non matching reply', async () => {
+    awaitingContactMessages[123] = 2;
+    const msg = { chat: { id: 123 }, text: 'no', reply_to_message: { message_id: 1 } };
+
+    const res = await processContactUsResponse(botMock, msg);
+
+    expect(res).toBe(false);
+    expect(sendMessageToAdmins).not.toHaveBeenCalled();
+  });
+});

--- a/src/commandsHandler/index.js
+++ b/src/commandsHandler/index.js
@@ -14,6 +14,11 @@ const { resetCacheForChat } = require('./resetCacheHandler');
 const { handleScrapingTrigger } = require('./scrapingTriggerHandler');
 const { handleBillingStats } = require('./billingStatsHandler');
 const { displayMenuMessage } = require('./menuHandler');
+const {
+  handleContactUsCommand,
+  handleContactCallback,
+  processContactUsResponse,
+} = require('./contactUsHandler');
 
 module.exports = {
   handleBestTeamsMessage,
@@ -31,4 +36,7 @@ module.exports = {
   handleScrapingTrigger,
   handleBillingStats,
   displayMenuMessage,
+  handleContactUsCommand,
+  handleContactCallback,
+  processContactUsResponse,
 };

--- a/src/constants.js
+++ b/src/constants.js
@@ -14,6 +14,7 @@ exports.WITHOUT_CHIP = 'WITHOUT_CHIP';
 exports.PHOTO_CALLBACK_TYPE = 'PHOTO';
 exports.CHIP_CALLBACK_TYPE = 'CHIP';
 exports.MENU_CALLBACK_TYPE = 'MENU';
+exports.CONTACT_CALLBACK_TYPE = 'CONTACT';
 
 exports.COMMAND_BEST_TEAMS = '/best_teams';
 exports.COMMAND_CURRENT_TEAM_INFO = '/current_team_info';
@@ -28,6 +29,7 @@ exports.COMMAND_GET_BOTFATHER_COMMANDS = '/get_botfather_commands';
 exports.COMMAND_NEXT_RACE_INFO = '/next_race_info';
 exports.COMMAND_BILLING_STATS = '/billing_stats';
 exports.COMMAND_MENU = '/menu';
+exports.COMMAND_CONTACT_US = '/contact_us';
 
 // Menu configuration for interactive menu command
 exports.MENU_CATEGORIES = {
@@ -46,6 +48,11 @@ exports.MENU_CATEGORIES = {
         constant: exports.COMMAND_MENU,
         title: '📱 Menu',
         description: 'Show interactive menu with all available commands.',
+      },
+      {
+        constant: exports.COMMAND_CONTACT_US,
+        title: '✉️ Contact Us',
+        description: 'Send a message to the bot admins.',
       },
     ],
   },

--- a/src/messageHandler.js
+++ b/src/messageHandler.js
@@ -5,16 +5,33 @@ const {
 } = require('./utils/utils');
 const { handleTextMessage } = require('./textMessageHandler');
 const { handlePhotoMessage } = require('./photoMessageHandler');
+const {
+  handleContactUsCommand,
+  processContactUsResponse,
+} = require('./commandsHandler/contactUsHandler');
+const { COMMAND_CONTACT_US } = require('./constants');
 
 exports.handleMessage = async function (bot, msg) {
   const chatId = msg.chat.id;
   const chatName = getChatName(msg);
 
   if (!isAdminMessage(msg)) {
-    await sendLogMessage(
-      bot,
-      `Message from unknown chat: ${chatName} (${chatId})`
-    );
+    if (msg.text === COMMAND_CONTACT_US) {
+      await handleContactUsCommand(bot, msg);
+
+      return;
+    }
+
+    const handled = msg.text
+      ? await processContactUsResponse(bot, msg)
+      : false;
+
+    if (!handled) {
+      await sendLogMessage(
+        bot,
+        `Message from unknown chat: ${chatName} (${chatId})`
+      );
+    }
 
     return;
   }

--- a/src/messageHandler.test.js
+++ b/src/messageHandler.test.js
@@ -8,6 +8,15 @@ jest.mock('./utils/utils', () => ({
   isAdminMessage: mockIsAdmin,
 }));
 
+const mockHandleContactUsCommand = jest.fn();
+const mockHandleContactCallback = jest.fn();
+const mockProcessContactUsResponse = jest.fn();
+jest.mock('./commandsHandler/contactUsHandler', () => ({
+  handleContactUsCommand: mockHandleContactUsCommand,
+  handleContactCallback: mockHandleContactCallback,
+  processContactUsResponse: mockProcessContactUsResponse,
+}));
+
 const { handleMessage } = require('./messageHandler');
 const { sendLogMessage } = require('./utils/utils');
 
@@ -56,6 +65,31 @@ describe('handleMessage', () => {
       botMock,
       'Message from unknown chat: Unknown (123456)'
     );
+  });
+
+  it('should handle /contact_us command from unknown sender', async () => {
+    const msgMock = {
+      chat: { id: 123456 },
+      text: '/contact_us',
+    };
+
+    await handleMessage(botMock, msgMock);
+
+    expect(mockHandleContactUsCommand).toHaveBeenCalledWith(botMock, msgMock);
+    expect(sendLogMessage).not.toHaveBeenCalled();
+  });
+
+  it('should process contact reply when from unknown sender', async () => {
+    const msgMock = {
+      chat: { id: 123456 },
+      text: 'hi there',
+    };
+    mockProcessContactUsResponse.mockResolvedValue(true);
+
+    await handleMessage(botMock, msgMock);
+
+    expect(mockProcessContactUsResponse).toHaveBeenCalledWith(botMock, msgMock);
+    expect(sendLogMessage).not.toHaveBeenCalled();
   });
 
   it('when got unsupported message', async () => {

--- a/src/textMessageHandler.js
+++ b/src/textMessageHandler.js
@@ -15,6 +15,7 @@ const {
   handleNextRaceInfoCommand,
   handleBillingStats,
   displayMenuMessage,
+  handleContactUsCommand,
 } = require('./commandsHandler');
 
 // Import constants
@@ -32,6 +33,7 @@ const {
   COMMAND_NEXT_RACE_INFO,
   COMMAND_BILLING_STATS,
   COMMAND_MENU,
+  COMMAND_CONTACT_US,
 } = require('./constants');
 
 exports.handleTextMessage = async function (bot, msg) {
@@ -72,6 +74,8 @@ exports.handleTextMessage = async function (bot, msg) {
       return await handleBillingStats(bot, msg);
     case msg.text === COMMAND_MENU:
       return await displayMenuMessage(bot, msg);
+    case msg.text === COMMAND_CONTACT_US:
+      return await handleContactUsCommand(bot, msg);
     default:
       handleJsonMessage(bot, msg, chatId);
       break;

--- a/src/textMessageHandler.test.js
+++ b/src/textMessageHandler.test.js
@@ -11,6 +11,7 @@ const {
   COMMAND_GET_BOTFATHER_COMMANDS,
   COMMAND_NEXT_RACE_INFO,
   COMMAND_CHIPS,
+  COMMAND_CONTACT_US,
 } = require('./constants');
 
 // Mock all command handlers
@@ -41,6 +42,7 @@ const {
 const {
   handleNextRaceInfoCommand,
 } = require('./commandsHandler/nextRaceInfoHandler');
+const { handleContactUsCommand } = require('./commandsHandler/contactUsHandler');
 
 jest.mock('./commandsHandler/numberInputHandler');
 jest.mock('./commandsHandler/jsonInputHandler');
@@ -55,6 +57,7 @@ jest.mock('./commandsHandler/loadSimulationHandler');
 jest.mock('./commandsHandler/scrapingTriggerHandler');
 jest.mock('./commandsHandler/getBotfatherCommandsHandler');
 jest.mock('./commandsHandler/nextRaceInfoHandler');
+jest.mock('./commandsHandler/contactUsHandler');
 
 const { handleTextMessage } = require('./textMessageHandler');
 
@@ -219,6 +222,18 @@ describe('handleTextMessage', () => {
         botMock,
         KILZI_CHAT_ID
       );
+      expect(handleJsonMessage).not.toHaveBeenCalled();
+    });
+
+    it('should route /contact_us command to handleContactUsCommand', async () => {
+      const msgMock = {
+        chat: { id: KILZI_CHAT_ID },
+        text: COMMAND_CONTACT_US,
+      };
+
+      await handleTextMessage(botMock, msgMock);
+
+      expect(handleContactUsCommand).toHaveBeenCalledWith(botMock, msgMock);
       expect(handleJsonMessage).not.toHaveBeenCalled();
     });
 


### PR DESCRIPTION
## Summary
- support new CONTACT_CALLBACK_TYPE constant
- extend contact handler with callback flow
- route CONTACT callbacks in callbackQueryHandler
- export new callback handler in index
- update tests for contact callback logic

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a30dc8b008326ab0ca4c3378419ea