### PR TITLE
Add menu fallback for unsupported messages

### DIFF
--- a/src/messageHandler.js
+++ b/src/messageHandler.js
@@ -5,6 +5,7 @@ const {
 } = require('./utils/utils');
 const { handleTextMessage } = require('./textMessageHandler');
 const { handlePhotoMessage } = require('./photoMessageHandler');
+const { displayMenuMessage } = require('./commandsHandler');
 
 exports.handleMessage = async function (bot, msg) {
   const chatId = msg.chat.id;
@@ -46,4 +47,7 @@ exports.handleMessage = async function (bot, msg) {
     .catch((err) =>
       console.error('Error sending unsupported type reply:', err)
     );
+
+  // Show interactive menu as a fallback
+  await displayMenuMessage(bot, msg);
 };

--- a/src/messageHandler.test.js
+++ b/src/messageHandler.test.js
@@ -8,8 +8,13 @@ jest.mock('./utils/utils', () => ({
   isAdminMessage: mockIsAdmin,
 }));
 
+jest.mock('./commandsHandler', () => ({
+  displayMenuMessage: jest.fn(),
+}));
+
 const { handleMessage } = require('./messageHandler');
 const { sendLogMessage } = require('./utils/utils');
+const { displayMenuMessage } = require('./commandsHandler');
 
 jest.mock('openai', () => ({
   AzureOpenAI: jest.fn().mockImplementation(() => ({
@@ -70,6 +75,7 @@ describe('handleMessage', () => {
       msgMock.chat.id,
       'Sorry, I only support text and image messages.'
     );
+    expect(displayMenuMessage).toHaveBeenCalledWith(botMock, msgMock);
     expect(sendLogMessage).toHaveBeenCalledTimes(2);
     expect(sendLogMessage).toHaveBeenCalledWith(
       botMock,


### PR DESCRIPTION
## Summary
- show the interactive menu when an unsupported message type is received
- test the new fallback

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a373d86e0832fa519eec019389f27