### PR TITLE
Fix red flags count check

### DIFF
--- a/src/commandsHandler/nextRaceInfoHandler.js
+++ b/src/commandsHandler/nextRaceInfoHandler.js
@@ -150,7 +150,7 @@ async function handleNextRaceInfoCommand(bot, chatId) {
         if (data.safetyCars !== undefined) {
           message += `⚠️🚓 Safety Cars: ${data.safetyCars}\n`;
         }
-        if (data.safetyCars !== undefined) {
+        if (data.redFlags !== undefined) {
           message += `🚩 Red Flags: ${data.redFlags}\n`;
         }
         message += `\n`;


### PR DESCRIPTION
## Summary
- fix historical red flags condition so red flags show up correctly

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a395c345c8326a98b3c188d7a782c