### PR TITLE
Add test environment support

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -234,6 +234,10 @@ Enter numbers when prompted by various commands for:
 - Uses webhook mode for efficient production operation
 - Integrates with Azure ecosystem for scalability
 
+#### Test Deployment
+
+- Mirrors production configuration using webhook mode
+
 ## Project Structure
 
 ```

--- a/src/bot.js
+++ b/src/bot.js
@@ -13,12 +13,12 @@ if (!TELEGRAM_BOT_TOKEN) {
 
 // Create a bot instance.
 let bot;
-if (NODE_ENV !== 'production') {
+if (NODE_ENV === 'production' || NODE_ENV === 'test') {
+  console.log(`Running in ${NODE_ENV} mode`);
+  bot = new TelegramBot(TELEGRAM_BOT_TOKEN, { polling: false });
+} else {
   console.log('Running in development mode');
   bot = new TelegramBot(TELEGRAM_BOT_TOKEN, { polling: true });
-} else {
-  console.log('Running in production mode');
-  bot = new TelegramBot(TELEGRAM_BOT_TOKEN, { polling: false });
 }
 
 // Send a message to the log channel that the bot has started.

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -30,10 +30,17 @@ exports.sendLogMessage = async function (bot, logMessage) {
     return;
   }
 
-  let log = `BOT: ${logMessage}
-env: ${process.env.NODE_ENV === 'production' ? 'prod' : 'dev'}`;
-
+  let env = 'dev';
   if (process.env.NODE_ENV === 'production') {
+    env = 'prod';
+  } else if (process.env.NODE_ENV === 'test') {
+    env = 'test';
+  }
+
+  let log = `BOT: ${logMessage}
+env: ${env}`;
+
+  if (process.env.NODE_ENV === 'production' || process.env.NODE_ENV === 'test') {
     log += `
 pid: ${process.pid}`;
   }

--- a/src/utils/utils.test.js
+++ b/src/utils/utils.test.js
@@ -102,7 +102,21 @@ describe('utils', () => {
       );
     });
 
-    it('when NODE_ENV is not production, log message contains dev', async () => {
+    it('when NODE_ENV is test, log message contains test', async () => {
+      process.env.NODE_ENV = 'test';
+      const botMock = {
+        sendMessage: jest.fn(),
+      };
+
+      await sendLogMessage(botMock, 'Log message in test');
+
+      expect(botMock.sendMessage).toHaveBeenCalledWith(
+        expect.any(Number), // LOG_CHANNEL_ID
+        expect.stringContaining('env: test')
+      );
+    });
+
+    it('when NODE_ENV is development, log message contains dev', async () => {
       process.env.NODE_ENV = 'development';
       const botMock = {
         sendMessage: jest.fn(),


### PR DESCRIPTION
## Summary
- support `test` environment using webhook like production
- show env information in logs for `test` mode
- test log messages for the new environment
- document test deployment in README

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a5b89a0948326b90048dae9c584a2