### PR TITLE
Add sendMessage try/catch

### DIFF
--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -48,7 +48,11 @@ pid: ${process.pid}`;
 
   console.log(log);
 
-  await exports.sendMessage(bot, LOG_CHANNEL_ID, log);
+  try {
+    await exports.sendMessage(bot, LOG_CHANNEL_ID, log);
+  } catch (error) {
+    console.error(error);
+  }
 };
 
 exports.sendMessageToAdmins = async function (bot, message) {
@@ -57,6 +61,18 @@ exports.sendMessageToAdmins = async function (bot, message) {
 
   for (const chatId of adminChatIds) {
     await exports.sendMessage(bot, chatId, msg);
+  }
+};
+
+exports.sendMessageToUser = async function (bot, message) {
+  try {
+    await exports.sendMessage(bot, KILZI_CHAT_ID, message);
+  } catch (error) {
+    console.error(error);
+    await exports.sendLogMessage(
+      bot,
+      `Error sending message to user: ${error.message}`
+    );
   }
 };
 

--- a/src/utils/utils.test.js
+++ b/src/utils/utils.test.js
@@ -1,10 +1,13 @@
+const utils = require('./utils');
 const {
   getChatName,
   sendLogMessage,
+  sendMessageToUser,
   calculateTeamInfo,
   validateJsonData,
   formatDateTime,
-} = require('./utils');
+} = utils;
+const { KILZI_CHAT_ID } = require('../constants');
 
 describe('utils', () => {
   describe('getChatName', () => {
@@ -128,6 +131,54 @@ describe('utils', () => {
         expect.any(Number), // LOG_CHANNEL_ID
         expect.stringContaining('env: dev')
       );
+    });
+
+    it('logs error when sendMessage fails', async () => {
+      const error = new Error('fail');
+      const botMock = {
+        sendMessage: jest.fn().mockRejectedValue(error),
+      };
+      const consoleErrorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      await sendLogMessage(botMock, 'some log');
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(error);
+
+      consoleErrorSpy.mockRestore();
+    });
+  });
+
+  describe('sendMessageToUser', () => {
+    it('sends message to the user chat ID', async () => {
+      const botMock = { sendMessage: jest.fn().mockResolvedValue() };
+
+      await sendMessageToUser(botMock, 'hello');
+
+      expect(botMock.sendMessage).toHaveBeenCalledWith(KILZI_CHAT_ID, 'hello');
+    });
+
+    it('logs error and calls sendLogMessage on failure', async () => {
+      const error = new Error('fail');
+      const botMock = { sendMessage: jest.fn().mockRejectedValue(error) };
+      const consoleErrorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      const sendLogSpy = jest
+        .spyOn(utils, 'sendLogMessage')
+        .mockResolvedValue();
+
+      await sendMessageToUser(botMock, 'hi');
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(error);
+      expect(sendLogSpy).toHaveBeenCalledWith(
+        botMock,
+        `Error sending message to user: ${error.message}`
+      );
+
+      consoleErrorSpy.mockRestore();
+      sendLogSpy.mockRestore();
     });
   });
 


### PR DESCRIPTION
## Summary
- guard sendLogMessage sendMessage call with a try/catch
- test logging behaviour when sendMessage fails

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6882189166d88326b44fb0865b08d800