### PR TITLE
Store user settings in Azure storage

### DIFF
--- a/src/cacheInitializer.js
+++ b/src/cacheInitializer.js
@@ -5,6 +5,7 @@ const {
   simulationInfoCache,
   sharedKey,
   nextRaceInfoCache,
+  languageCache,
 } = require('./cache');
 const {
   sendLogMessage,
@@ -19,6 +20,7 @@ const {
 const {
   getFantasyData,
   listAllUserTeamData,
+  listAllUserSettingsData,
   getNextRaceInfoData,
 } = require('./azureStorageService');
 
@@ -50,6 +52,19 @@ async function initializeCaches(bot) {
   await sendLogMessage(
     bot,
     `Loaded ${Object.keys(userTeams).length} user teams from storage`
+  );
+
+  // Load all user settings into cache
+  const userSettings = await listAllUserSettingsData();
+  Object.entries(userSettings).forEach(([id, settings]) => {
+    if (settings.lang) {
+      languageCache[id] = settings.lang;
+    }
+  });
+
+  await sendLogMessage(
+    bot,
+    `Loaded ${Object.keys(userSettings).length} user settings from storage`
   );
 }
 

--- a/src/callbackQueryHandler.js
+++ b/src/callbackQueryHandler.js
@@ -137,6 +137,7 @@ async function handleLanguageCallback(bot, query) {
   const lang = query.data.split(':')[1];
 
   setLanguage(lang, chatId);
+  await azureStorageService.saveUserSettings(bot, chatId, { lang });
 
   await bot.editMessageText(
     t('Language changed to {LANG}.', chatId, { LANG: getLanguageName(lang, chatId) }),

--- a/src/callbackQueryHandler.test.js
+++ b/src/callbackQueryHandler.test.js
@@ -41,6 +41,7 @@ jest.mock('openai', () => ({
 jest.mock('./jsonDataExtraction');
 jest.mock('./azureStorageService', () => ({
   saveUserTeam: jest.fn().mockResolvedValue(undefined),
+  saveUserSettings: jest.fn().mockResolvedValue(undefined),
   deleteUserTeam: jest.fn().mockResolvedValue(undefined),
 }));
 jest.mock('./cache', () => ({
@@ -371,6 +372,11 @@ describe('handleCallbackQuery', () => {
       );
       expect(bot.answerCallbackQuery).toHaveBeenCalledWith('langQueryId');
       expect(getLanguage(chatId)).toBe('he');
+      expect(azureStorageService.saveUserSettings).toHaveBeenCalledWith(
+        bot,
+        chatId,
+        { lang: 'he' }
+      );
     });
   });
 

--- a/src/commandsHandler/setLanguageHandler.js
+++ b/src/commandsHandler/setLanguageHandler.js
@@ -1,5 +1,6 @@
 const { t, setLanguage, getSupportedLanguages, getLanguageName } = require('../i18n');
 const { LANG_CALLBACK_TYPE } = require('../constants');
+const azureStorageService = require('../azureStorageService');
 
 async function handleSetLanguage(bot, msg) {
   const chatId = msg.chat.id;
@@ -25,6 +26,7 @@ async function handleSetLanguage(bot, msg) {
   }
 
   if (setLanguage(lang, chatId)) {
+    await azureStorageService.saveUserSettings(bot, chatId, { lang });
     await bot
       .sendMessage(
         chatId,

--- a/src/commandsHandler/setLanguageHandler.test.js
+++ b/src/commandsHandler/setLanguageHandler.test.js
@@ -1,4 +1,8 @@
 const { KILZI_CHAT_ID } = require('../constants');
+jest.mock('../azureStorageService', () => ({
+  saveUserSettings: jest.fn().mockResolvedValue(undefined),
+}));
+const azureStorageService = require('../azureStorageService');
 const { getLanguage, languageCache, t, getLanguageName } = require('../i18n');
 const { handleSetLanguage } = require('./setLanguageHandler');
 
@@ -22,6 +26,11 @@ describe('handleSetLanguage', () => {
       KILZI_CHAT_ID,
       t('Language changed to {LANG}.', KILZI_CHAT_ID, { LANG: getLanguageName('he', KILZI_CHAT_ID) })
     );
+    expect(azureStorageService.saveUserSettings).toHaveBeenCalledWith(
+      botMock,
+      KILZI_CHAT_ID,
+      { lang: 'he' }
+    );
   });
 
   it('should send invalid language message for unsupported code', async () => {
@@ -34,6 +43,7 @@ describe('handleSetLanguage', () => {
       KILZI_CHAT_ID,
       t('Invalid language. Supported languages: {LANGS}', KILZI_CHAT_ID, { LANGS: 'en, he' })
     );
+    expect(azureStorageService.saveUserSettings).not.toHaveBeenCalled();
   });
 
   it('should send usage message when no language provided', async () => {
@@ -50,5 +60,6 @@ describe('handleSetLanguage', () => {
         reply_markup: { inline_keyboard: expect.any(Array) },
       })
     );
+    expect(azureStorageService.saveUserSettings).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- persist user settings per user in blob storage
- save settings on language change
- load settings during cache initialization
- preserve existing settings when updating language
- call `getUserSettings` from `saveUserSettings` to avoid duplicating logic
- add unit tests for new behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68826a911a64832f847f7fd421f75184