### PR TITLE
Add missing translation and BotFather command improvements

### DIFF
--- a/src/commandsHandler/getBotfatherCommandsHandler.js
+++ b/src/commandsHandler/getBotfatherCommandsHandler.js
@@ -15,7 +15,7 @@ async function handleGetBotfatherCommands(bot, msg) {
   }
 
   const botFatherCommands = USER_COMMANDS_CONFIG.map(
-    (cmd) => `${cmd.constant.substring(1)} - ${t(cmd.description, chatId)}`
+    (cmd) => `${cmd.constant.substring(1)} - ${cmd.description}`
   ).join('\n');
 
   await bot

--- a/src/commandsHandler/getBotfatherCommandsHandler.test.js
+++ b/src/commandsHandler/getBotfatherCommandsHandler.test.js
@@ -7,6 +7,7 @@ jest.mock('../utils', () => ({
 }));
 
 const { handleGetBotfatherCommands } = require('./getBotfatherCommandsHandler');
+const { setLanguage, t } = require('../i18n');
 
 describe('handleGetBotfatherCommands', () => {
   const botMock = {
@@ -151,5 +152,27 @@ describe('handleGetBotfatherCommands', () => {
       KILZI_CHAT_ID,
       expect.any(String)
     );
+  });
+
+  it('should not translate descriptions even if language differs', async () => {
+    const msgMock = {
+      chat: { id: KILZI_CHAT_ID },
+      text: '/get_botfather_commands',
+    };
+
+    setLanguage('he', KILZI_CHAT_ID);
+
+    await handleGetBotfatherCommands(botMock, msgMock);
+
+    const sentMessage = botMock.sendMessage.mock.calls[0][1];
+
+    USER_COMMANDS_CONFIG.forEach((cmd) => {
+      expect(sentMessage).toContain(
+        `${cmd.constant.substring(1)} - ${cmd.description}`
+      );
+      expect(sentMessage).not.toContain(
+        `(${t(cmd.description, KILZI_CHAT_ID)})`
+      );
+    });
   });
 });

--- a/src/translations.js
+++ b/src/translations.js
@@ -16,6 +16,8 @@ const translations = {
     'Wildcard': 'ווילדקארד',
     'Without Chip': 'ללא צ\'יפ',
     'Sorry, only admins can use this command.': 'מצטער, רק מנהלים יכולים להשתמש בפקודה זו.',
+    'Sorry, only admins can get BotFather commands.':
+      'מצטער, רק מנהלים יכולים לקבל פקודות BotFather.',
     'Simulation data fetched and cached successfully.': 'נתוני הסימולציה נטענו ונשמרו בהצלחה.',
     'Failed to load simulation data: {ERROR}': 'נכשל לטעון נתוני סימולציה: {ERROR}',
     'Cache has been reset for your chat.': 'המטמון אופס עבור הצ\'אט שלך.',
@@ -157,6 +159,7 @@ const translations = {
     'Calculate and display the best possible teams based on your cached data':
       'חשב והצג את הקבוצות הטובות ביותר על סמך הנתונים במטמון',
     '👥 Current Team Info': '👥 מידע על הקבוצה הנוכחית',
+    'Current Team Info': 'מידע על הקבוצה הנוכחית',
     'Calculate the current team info based on your cached data':
       'חשב את מידע הקבוצה הנוכחית על סמך הנתונים במטמון',
     '🎯 Chips Selection': "🎯 בחירת צ'יפ",


### PR DESCRIPTION
## Summary
- add Hebrew translations for "Current Team Info" and BotFather admin warning
- simplify BotFather command descriptions to always show the English text
- adjust tests accordingly

## Testing
- `npm test --silent`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68834bd80a2c832fa78d2c174df5e5fa