### PR TITLE
Add hidden chip selection commands

### DIFF
--- a/src/callbackQueryHandler.js
+++ b/src/callbackQueryHandler.js
@@ -7,8 +7,8 @@ const {
   driversCache,
   getPrintableCache,
   bestTeamsCache,
-  selectedChipCache,
 } = require('./cache');
+const { selectChip } = require('./commandsHandler/selectChipHandlers');
 const {
   DRIVERS_PHOTO_TYPE,
   CONSTRUCTORS_PHOTO_TYPE,
@@ -18,8 +18,6 @@ const {
   CHIP_CALLBACK_TYPE,
   MENU_CALLBACK_TYPE,
   LANG_CALLBACK_TYPE,
-  WITHOUT_CHIP,
-  COMMAND_BEST_TEAMS,
 } = require('./constants');
 
 const { sendLogMessage } = require('./utils');
@@ -99,28 +97,8 @@ async function handleChipCallback(bot, query) {
   const chatId = query.message.chat.id;
   const messageId = query.message.message_id;
   const chip = query.data.split(':')[1];
-  selectedChipCache[chatId] = chip;
-  if (chip === WITHOUT_CHIP) {
-    delete selectedChipCache[chatId];
-  }
 
-  const isThereDataInBestTeamsCache =
-    bestTeamsCache[chatId] && bestTeamsCache[chatId].bestTeams;
-
-  // Clear best teams cache when user selects a chip
-  delete bestTeamsCache[chatId];
-
-  let message = t('Selected chip: {CHIP}.', chatId, { CHIP: chip.toUpperCase() });
-
-  if (isThereDataInBestTeamsCache) {
-    message +=
-      '\n' +
-      t(
-        'Note: best team calculation was deleted.\nrerun {CMD} command to recalculate best teams.',
-        chatId,
-        { CMD: COMMAND_BEST_TEAMS }
-      );
-  }
+  const message = selectChip(chatId, chip);
 
   await bot.editMessageText(message, {
     chat_id: chatId,

--- a/src/commandsHandler/askHandler.test.js
+++ b/src/commandsHandler/askHandler.test.js
@@ -25,6 +25,7 @@ jest.mock('./numberInputHandler', () => ({
 const { handleBestTeamsMessage } = require('./bestTeamsHandler');
 const { handleNumberMessage } = require('./numberInputHandler');
 const { handleAskCommand } = require('./askHandler');
+const { ASK_SYSTEM_PROMPT } = require('../prompts');
 
 describe('handleAskCommand', () => {
   const botMock = { sendMessage: jest.fn().mockResolvedValue() };
@@ -57,5 +58,24 @@ describe('handleAskCommand', () => {
       KILZI_CHAT_ID,
       'Please provide a question.'
     );
+  });
+
+  it('should use ASK_SYSTEM_PROMPT when calling AzureOpenAI', async () => {
+    const msgMock = { chat: { id: KILZI_CHAT_ID }, text: 'question' };
+    const mockResponse = {
+      choices: [{ message: { content: '[]' } }],
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+    };
+    __createMock.mockResolvedValue(mockResponse);
+
+    await handleAskCommand(botMock, msgMock);
+
+    expect(__createMock).toHaveBeenCalledWith({
+      model: undefined,
+      messages: [
+        { role: 'system', content: ASK_SYSTEM_PROMPT },
+        { role: 'user', content: 'question' },
+      ],
+    });
   });
 });

--- a/src/commandsHandler/commandHandlers.js
+++ b/src/commandsHandler/commandHandlers.js
@@ -14,6 +14,10 @@ const {
   COMMAND_VERSION,
   COMMAND_MENU,
   COMMAND_SET_LANGUAGE,
+  COMMAND_EXTRA_DRS,
+  COMMAND_LIMITLESS,
+  COMMAND_WILDCARD,
+  COMMAND_RESET_CHIP,
 } = require('../constants');
 
 const { handleBestTeamsMessage } = require('./bestTeamsHandler');
@@ -31,6 +35,12 @@ const { handleBillingStats } = require('./billingStatsHandler');
 const { handleVersionCommand } = require('./versionHandler');
 const { displayMenuMessage } = require('./menuHandler');
 const { handleSetLanguage } = require('./setLanguageHandler');
+const {
+  handleSelectExtraDrs,
+  handleSelectLimitless,
+  handleSelectWildcard,
+  handleResetChip,
+} = require('./selectChipHandlers');
 
 // Mapping of command constants to their handler functions
 const COMMAND_HANDLERS = {
@@ -49,6 +59,10 @@ const COMMAND_HANDLERS = {
   [COMMAND_VERSION]: handleVersionCommand,
   [COMMAND_MENU]: displayMenuMessage,
   [COMMAND_SET_LANGUAGE]: handleSetLanguage,
+  [COMMAND_EXTRA_DRS]: handleSelectExtraDrs,
+  [COMMAND_LIMITLESS]: handleSelectLimitless,
+  [COMMAND_WILDCARD]: handleSelectWildcard,
+  [COMMAND_RESET_CHIP]: handleResetChip,
 };
 
 async function executeCommand(bot, msg, command) {

--- a/src/commandsHandler/index.js
+++ b/src/commandsHandler/index.js
@@ -17,6 +17,12 @@ const { displayMenuMessage } = require('./menuHandler');
 const { handleVersionCommand } = require('./versionHandler');
 const { handleSetLanguage } = require('./setLanguageHandler');
 const { handleAskCommand } = require('./askHandler');
+const {
+  handleSelectExtraDrs,
+  handleSelectLimitless,
+  handleSelectWildcard,
+  handleResetChip,
+} = require('./selectChipHandlers');
 
 module.exports = {
   handleBestTeamsMessage,
@@ -37,4 +43,8 @@ module.exports = {
   handleVersionCommand,
   handleSetLanguage,
   handleAskCommand,
+  handleSelectExtraDrs,
+  handleSelectLimitless,
+  handleSelectWildcard,
+  handleResetChip,
 };

--- a/src/commandsHandler/selectChipHandlers.js
+++ b/src/commandsHandler/selectChipHandlers.js
@@ -1,0 +1,65 @@
+const { selectedChipCache, bestTeamsCache } = require('../cache');
+const {
+  EXTRA_DRS_CHIP,
+  LIMITLESS_CHIP,
+  WILDCARD_CHIP,
+  WITHOUT_CHIP,
+  COMMAND_BEST_TEAMS,
+} = require('../constants');
+const { t } = require('../i18n');
+
+function selectChip(chatId, chip) {
+  const isThereDataInBestTeamsCache =
+    bestTeamsCache[chatId] && bestTeamsCache[chatId].bestTeams;
+
+  if (chip === WITHOUT_CHIP) {
+    delete selectedChipCache[chatId];
+  } else {
+    selectedChipCache[chatId] = chip;
+  }
+
+  delete bestTeamsCache[chatId];
+
+  let message = t('Selected chip: {CHIP}.', chatId, { CHIP: chip.toUpperCase() });
+
+  if (isThereDataInBestTeamsCache) {
+    message +=
+      '\n' +
+      t(
+        'Note: best team calculation was deleted.\nrerun {CMD} command to recalculate best teams.',
+        chatId,
+        { CMD: COMMAND_BEST_TEAMS }
+      );
+  }
+
+  return message;
+}
+
+async function sendChipSelection(bot, chatId, chip) {
+  const message = selectChip(chatId, chip);
+  await bot.sendMessage(chatId, message);
+}
+
+async function handleSelectExtraDrs(bot, msg) {
+  await sendChipSelection(bot, msg.chat.id, EXTRA_DRS_CHIP);
+}
+
+async function handleSelectLimitless(bot, msg) {
+  await sendChipSelection(bot, msg.chat.id, LIMITLESS_CHIP);
+}
+
+async function handleSelectWildcard(bot, msg) {
+  await sendChipSelection(bot, msg.chat.id, WILDCARD_CHIP);
+}
+
+async function handleResetChip(bot, msg) {
+  await sendChipSelection(bot, msg.chat.id, WITHOUT_CHIP);
+}
+
+module.exports = {
+  handleSelectExtraDrs,
+  handleSelectLimitless,
+  handleSelectWildcard,
+  handleResetChip,
+  selectChip,
+};

--- a/src/commandsHandler/selectChipHandlers.test.js
+++ b/src/commandsHandler/selectChipHandlers.test.js
@@ -1,0 +1,38 @@
+const { KILZI_CHAT_ID, EXTRA_DRS_CHIP, WILDCARD_CHIP, WITHOUT_CHIP } = require('../constants');
+const { bestTeamsCache, selectedChipCache } = require('../cache');
+const { handleSelectExtraDrs, handleResetChip } = require('./selectChipHandlers');
+
+describe('select chip handlers', () => {
+  const botMock = { sendMessage: jest.fn().mockResolvedValue() };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    delete bestTeamsCache[KILZI_CHAT_ID];
+    delete selectedChipCache[KILZI_CHAT_ID];
+  });
+
+  it('should select EXTRA_DRS chip and clear bestTeamsCache', async () => {
+    bestTeamsCache[KILZI_CHAT_ID] = { some: 'data' };
+
+    await handleSelectExtraDrs(botMock, { chat: { id: KILZI_CHAT_ID } });
+
+    expect(selectedChipCache[KILZI_CHAT_ID]).toBe(EXTRA_DRS_CHIP);
+    expect(bestTeamsCache[KILZI_CHAT_ID]).toBeUndefined();
+    expect(botMock.sendMessage).toHaveBeenCalledWith(
+      KILZI_CHAT_ID,
+      expect.stringContaining(`Selected chip: ${EXTRA_DRS_CHIP}.`)
+    );
+  });
+
+  it('should reset chip selection', async () => {
+    selectedChipCache[KILZI_CHAT_ID] = WILDCARD_CHIP;
+
+    await handleResetChip(botMock, { chat: { id: KILZI_CHAT_ID } });
+
+    expect(selectedChipCache[KILZI_CHAT_ID]).toBeUndefined();
+    expect(botMock.sendMessage).toHaveBeenCalledWith(
+      KILZI_CHAT_ID,
+      expect.stringContaining(`Selected chip: ${WITHOUT_CHIP}.`)
+    );
+  });
+});

--- a/src/constants.js
+++ b/src/constants.js
@@ -33,6 +33,10 @@ exports.COMMAND_BILLING_STATS = '/billing_stats';
 exports.COMMAND_VERSION = '/version';
 exports.COMMAND_MENU = '/menu';
 exports.COMMAND_SET_LANGUAGE = '/lang';
+exports.COMMAND_EXTRA_DRS = '/extra_drs';
+exports.COMMAND_LIMITLESS = '/limitless';
+exports.COMMAND_WILDCARD = '/wildcard';
+exports.COMMAND_RESET_CHIP = '/reset_chip';
 
 // Menu configuration for interactive menu command
 exports.MENU_CATEGORIES = {

--- a/src/prompts.js
+++ b/src/prompts.js
@@ -99,5 +99,7 @@ exports.ASK_SYSTEM_PROMPT = `You are an assistant for a Telegram bot that manage
 Convert a free text request into an ordered list of bot commands to execute.
 Allowed commands: /best_teams, /current_team_info, /chips, /extra_drs, /limitless, /wildcard, /reset_chip, /print_cache, /reset_cache, /help, /trigger_scraping, /load_simulation, /get_current_simulation, /get_botfather_commands, /next_race_info, /billing_stats, /version, /menu, /lang.
 Numbers may be used to request team details after /best_teams.
+When asking for best teams with a chip, place the chip command before /best_teams.
+For best teams without a chip, place /reset_chip before /best_teams.
 Respond only with a JSON array of commands.
 Example: "give me the details of the best 3 teams" -> ["/best_teams", "1", "2", "3"]`;

--- a/src/prompts.js
+++ b/src/prompts.js
@@ -97,7 +97,7 @@ type Json = {
 
 exports.ASK_SYSTEM_PROMPT = `You are an assistant for a Telegram bot that manages F1 Fantasy teams.
 Convert a free text request into an ordered list of bot commands to execute.
-Allowed commands: /best_teams, /current_team_info, /chips, /print_cache, /reset_cache, /help, /trigger_scraping, /load_simulation, /get_current_simulation, /get_botfather_commands, /next_race_info, /billing_stats, /version, /menu, /lang.
+Allowed commands: /best_teams, /current_team_info, /chips, /extra_drs, /limitless, /wildcard, /reset_chip, /print_cache, /reset_cache, /help, /trigger_scraping, /load_simulation, /get_current_simulation, /get_botfather_commands, /next_race_info, /billing_stats, /version, /menu, /lang.
 Numbers may be used to request team details after /best_teams.
 Respond only with a JSON array of commands.
 Example: "give me the details of the best 3 teams" -> ["/best_teams", "1", "2", "3"]`;

--- a/src/textMessageHandler.js
+++ b/src/textMessageHandler.js
@@ -18,6 +18,10 @@ const {
   handleVersionCommand,
   handleSetLanguage,
   handleAskCommand,
+  handleSelectExtraDrs,
+  handleSelectLimitless,
+  handleSelectWildcard,
+  handleResetChip,
 } = require('./commandsHandler');
 
 // Import constants
@@ -37,6 +41,10 @@ const {
   COMMAND_VERSION,
   COMMAND_MENU,
   COMMAND_SET_LANGUAGE,
+  COMMAND_EXTRA_DRS,
+  COMMAND_LIMITLESS,
+  COMMAND_WILDCARD,
+  COMMAND_RESET_CHIP,
 } = require('./constants');
 
 exports.handleTextMessage = async function (bot, msg) {
@@ -57,6 +65,14 @@ exports.handleTextMessage = async function (bot, msg) {
       return await calcCurrentTeamInfo(bot, chatId);
     case msg.text === COMMAND_CHIPS:
       return await handleChipsMessage(bot, msg);
+    case msg.text === COMMAND_EXTRA_DRS:
+      return await handleSelectExtraDrs(bot, msg);
+    case msg.text === COMMAND_LIMITLESS:
+      return await handleSelectLimitless(bot, msg);
+    case msg.text === COMMAND_WILDCARD:
+      return await handleSelectWildcard(bot, msg);
+    case msg.text === COMMAND_RESET_CHIP:
+      return await handleResetChip(bot, msg);
     case msg.text === COMMAND_PRINT_CACHE:
       return await sendPrintableCache(chatId, bot);
     case msg.text === COMMAND_RESET_CACHE:


### PR DESCRIPTION
## Summary
- create generic chip selection handlers
- wire new chip commands in constants, command mappings, and text handler
- expose hidden chip commands for AI prompt
- test chip selection handlers
- refactor chip selection logic to avoid duplication

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6883a0176de4832f9d8c6fef06a22030