### PR TITLE
Add spacing before next races summary

### DIFF
--- a/src/commandsHandler/nextRacesHandler.js
+++ b/src/commandsHandler/nextRacesHandler.js
@@ -201,6 +201,29 @@ async function handleNextRacesCommand(bot, chatId) {
     const raceBlocks = upcomingRaces.map(
       (race) => buildRaceBlock(race, chatId).text
     );
+    const totalUpcomingRaces = upcomingRaces.length;
+    const sprintRacesCount = upcomingRaces.filter((race) => Boolean(race.Sprint)).length;
+
+    const buildSummaryLine = () => {
+      const raceSummary =
+        totalUpcomingRaces === 1
+          ? t('1 race left to go', chatId)
+          : t('{COUNT} races left to go', chatId, {
+              COUNT: totalUpcomingRaces,
+            });
+
+      const sprintSummary =
+        sprintRacesCount === 1
+          ? t('1 of them is sprint format', chatId)
+          : t('{COUNT} of them are sprint format', chatId, {
+              COUNT: sprintRacesCount,
+            });
+
+      return t('Summary: {RACES_SUMMARY}, {SPRINT_SUMMARY}', chatId, {
+        RACES_SUMMARY: raceSummary,
+        SPRINT_SUMMARY: sprintSummary,
+      });
+    };
 
     const messages = [];
     let currentMessage = header;
@@ -213,6 +236,16 @@ async function handleNextRacesCommand(bot, chatId) {
 
       currentMessage += block;
     });
+
+    const summaryLine = buildSummaryLine();
+    const summaryBlock = `\n\n\n${summaryLine}`;
+
+    if (currentMessage.length + summaryBlock.length > MAX_TELEGRAM_MESSAGE_LENGTH) {
+      messages.push(currentMessage.trimEnd());
+      currentMessage = `${continuedHeader}\n${summaryLine}\n`;
+    } else {
+      currentMessage = `${currentMessage.trimEnd()}${summaryBlock}\n`;
+    }
 
     if (currentMessage.trim().length > 0) {
       messages.push(currentMessage.trimEnd());

--- a/src/commandsHandler/nextRacesHandler.test.js
+++ b/src/commandsHandler/nextRacesHandler.test.js
@@ -125,6 +125,9 @@ describe('handleNextRacesCommand', () => {
     expect(sentMessage).toContain('📅 Sessions:');
     expect(sentMessage).toContain('FP1');
     expect(sentMessage).toContain('Canadian Grand Prix');
+    expect(sentMessage).toContain(
+      'Summary: 2 races left to go, 0 of them are sprint format'
+    );
   });
 
   it('should notify when no upcoming races are found', async () => {

--- a/src/translations.js
+++ b/src/translations.js
@@ -27,6 +27,12 @@ const translations = {
       'לא ניתן להביא את המרוצים הקרובים. נסה שוב מאוחר יותר.',
     'Upcoming Races': 'מרוצים קרובים',
     'Upcoming Races (continued)': 'מרוצים קרובים (המשך)',
+    'Summary: {RACES_SUMMARY}, {SPRINT_SUMMARY}':
+      'סיכום: {RACES_SUMMARY}, {SPRINT_SUMMARY}',
+    '1 race left to go': 'מרוץ אחד נותר לסיום',
+    '{COUNT} races left to go': '{COUNT} מרוצים נותרו לסיום',
+    '1 of them is sprint format': 'אחד מהם בפורמט ספרינט',
+    '{COUNT} of them are sprint format': '{COUNT} מהם בפורמט ספרינט',
     'Missing cached data. Please send images or JSON data for drivers, constructors, and current team first.':
       'נתוני מטמון חסרים. אנא שלח תמונות או קבצי JSON של נהגים, קבוצות וקבוצה נוכחית קודם.',
     'Please send a number to get the required changes to that team.':


### PR DESCRIPTION
## Summary
- add additional blank lines before the `/next_races` summary so the response shows two empty lines ahead of the totals

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d6437fdd148326814ffcd7ac3b8a96